### PR TITLE
chore: next.config.ts에서 불필요한 basePath 조건 제거

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  basePath: process.env.NODE_ENV === "production" ? "" : "",
   trailingSlash: true,
 };
 


### PR DESCRIPTION
## Summary
- 양쪽 모두 빈 문자열이던 무의미한 `basePath` 조건문 삭제
- 코드 가독성 향상

## Changes
- `next.config.ts`: 불필요한 basePath 조건 제거

## Test plan
- [x] 빌드 정상 확인

Closes #4