### PR TITLE
feat: About 페이지 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+#claude
+/claudedocs
+

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -14,137 +14,157 @@ const techStack = {
 
 export default function AboutPage() {
   return (
-    <div className="mx-auto max-w-3xl px-4 py-16">
-      {/* Header */}
-      <header className="mb-12">
-        <h1 className="text-4xl font-bold">
-          👋 Hello! I&apos;m <span className="text-blue-600 dark:text-blue-400">MinGyu</span>
-        </h1>
-        <p className="mt-4 text-xl text-zinc-600 dark:text-zinc-400">
-          🚀 풀스택을 꿈꾸는 개발자
-        </p>
-      </header>
- 
-      {/* About Me */}
-      <section className="mb-12">
-        <h2 className="mb-4 text-2xl font-semibold">🙋‍♂️ About Me</h2>
-        <ul className="space-y-2 text-zinc-600 dark:text-zinc-400">
-          <li className="flex items-start gap-2">
-            <span>🎯</span>
-            <span>풀스택 개발자가 되기 위해 끊임없이 성장 중</span>
-          </li>
-          <li className="flex items-start gap-2">
-            <span>💻</span>
-            <span>백엔드부터 프론트엔드까지 경험을 쌓고 있습니다</span>
-          </li>
-          <li className="flex items-start gap-2">
-            <span>📚</span>
-            <span>새로운 기술을 배우고 적용하는 것을 좋아합니다</span>
-          </li>
-        </ul>
-      </section>
+    <div className="relative mx-auto max-w-3xl px-4 py-16">
+      {/* Background Decorative Elements */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-gradient-to-br from-blue-500/10 to-purple-500/10 blur-3xl dark:from-blue-500/5 dark:to-purple-500/5" />
+        <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-gradient-to-tr from-green-500/10 to-blue-500/10 blur-3xl dark:from-green-500/5 dark:to-blue-500/5" />
+      </div>
 
-      {/* Tech Stack */}
-      <section className="mb-12">
-        <h2 className="mb-6 text-2xl font-semibold">🛠️ Tech Stack</h2>
+      {/* Content */}
+      <div className="relative">
+        {/* Header with gradient background */}
+        <header className="mb-12 animate-fade-in-up rounded-2xl bg-gradient-to-br from-blue-50 to-indigo-50 p-8 shadow-lg dark:from-blue-950/30 dark:to-indigo-950/30 dark:shadow-blue-900/20">
+          <h1 className="text-4xl font-bold md:text-5xl">
+            👋 Hello! I&apos;m{" "}
+            <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent dark:from-blue-400 dark:to-indigo-400">
+              MinGyu
+            </span>
+          </h1>
+          <p className="mt-4 text-xl text-zinc-700 dark:text-zinc-300">
+            🚀 풀스택을 꿈꾸는 개발자
+          </p>
+        </header>
 
-        <div className="grid gap-6 sm:grid-cols-2">
-          {/* Languages */}
-          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
-            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
-              💬 Languages
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {techStack.languages.map((lang) => (
-                <span
-                  key={lang}
-                  className="rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
-                >
-                  {lang}
-                </span>
-              ))}
+        {/* About Me with staggered animation */}
+        <section className="mb-12 animate-fade-in-up" style={{ animationDelay: "0.1s" }}>
+          <h2 className="mb-6 text-2xl font-semibold">🙋‍♂️ About Me</h2>
+          <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
+            <ul className="space-y-4 text-zinc-600 dark:text-zinc-400">
+              <li className="flex items-start gap-3 transition-transform duration-200 hover:translate-x-1">
+                <span className="text-2xl">🎯</span>
+                <span className="pt-1">풀스택 개발자가 되기 위해 끊임없이 성장 중</span>
+              </li>
+              <li className="flex items-start gap-3 transition-transform duration-200 hover:translate-x-1">
+                <span className="text-2xl">💻</span>
+                <span className="pt-1">백엔드부터 프론트엔드까지 경험을 쌓고 있습니다</span>
+              </li>
+              <li className="flex items-start gap-3 transition-transform duration-200 hover:translate-x-1">
+                <span className="text-2xl">📚</span>
+                <span className="pt-1">새로운 기술을 배우고 적용하는 것을 좋아합니다</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+
+        {/* Tech Stack with enhanced cards */}
+        <section className="mb-12 animate-fade-in-up" style={{ animationDelay: "0.2s" }}>
+          <h2 className="mb-6 text-2xl font-semibold">🛠️ Tech Stack</h2>
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            {/* Languages */}
+            <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
+              <h3 className="mb-4 flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+                <span className="text-xl">💬</span>
+                <span>Languages</span>
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {techStack.languages.map((lang) => (
+                  <span
+                    key={lang}
+                    className="cursor-default rounded-full bg-blue-100 px-3 py-1.5 text-sm font-medium text-blue-700 transition-all duration-200 hover:scale-105 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50"
+                  >
+                    {lang}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* Frameworks & Libraries */}
+            <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
+              <h3 className="mb-4 flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+                <span className="text-xl">🧩</span>
+                <span>Frameworks & Libraries</span>
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {techStack.frameworks.map((fw) => (
+                  <span
+                    key={fw}
+                    className="cursor-default rounded-full bg-green-100 px-3 py-1.5 text-sm font-medium text-green-700 transition-all duration-200 hover:scale-105 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-300 dark:hover:bg-green-900/50"
+                  >
+                    {fw}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* Databases */}
+            <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
+              <h3 className="mb-4 flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+                <span className="text-xl">🗄️</span>
+                <span>Databases</span>
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {techStack.databases.map((db) => (
+                  <span
+                    key={db}
+                    className="cursor-default rounded-full bg-orange-100 px-3 py-1.5 text-sm font-medium text-orange-700 transition-all duration-200 hover:scale-105 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:hover:bg-orange-900/50"
+                  >
+                    {db}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* Tools */}
+            <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
+              <h3 className="mb-4 flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
+                <span className="text-xl">🔧</span>
+                <span>Tools & Environment</span>
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {techStack.tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="cursor-default rounded-full bg-purple-100 px-3 py-1.5 text-sm font-medium text-purple-700 transition-all duration-200 hover:scale-105 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-300 dark:hover:bg-purple-900/50"
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
+        </section>
 
-          {/* Frameworks & Libraries */}
-          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
-            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
-              🧩 Frameworks & Libraries
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {techStack.frameworks.map((fw) => (
-                <span
-                  key={fw}
-                  className="rounded-full bg-green-100 px-3 py-1 text-sm text-green-700 dark:bg-green-900/30 dark:text-green-300"
+        {/* Contact with enhanced styling */}
+        <section className="animate-fade-in-up" style={{ animationDelay: "0.3s" }}>
+          <h2 className="mb-6 text-2xl font-semibold">📫 Contact</h2>
+          <div className="rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-900/50">
+            <ul className="space-y-4 text-zinc-600 dark:text-zinc-400">
+              <li className="flex items-center gap-3 transition-all duration-200 hover:translate-x-1">
+                <span className="font-medium text-zinc-900 dark:text-zinc-100">Email:</span>
+                <a
+                  href="mailto:mink906@gmail.com"
+                  className="text-blue-600 transition-colors duration-200 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
                 >
-                  {fw}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          {/* Databases */}
-          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
-            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
-              🗄️ Databases
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {techStack.databases.map((db) => (
-                <span
-                  key={db}
-                  className="rounded-full bg-orange-100 px-3 py-1 text-sm text-orange-700 dark:bg-orange-900/30 dark:text-orange-300"
+                  mink906@gmail.com
+                </a>
+              </li>
+              <li className="flex items-center gap-3 transition-all duration-200 hover:translate-x-1">
+                <span className="font-medium text-zinc-900 dark:text-zinc-100">GitHub:</span>
+                <a
+                  href="https://github.com/kmg733"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 transition-colors duration-200 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
                 >
-                  {db}
-                </span>
-              ))}
-            </div>
+                  @kmg733
+                </a>
+              </li>
+            </ul>
           </div>
-
-          {/* Tools */}
-          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
-            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
-              🔧 Tools & Environment
-            </h3>
-            <div className="flex flex-wrap gap-2">
-              {techStack.tools.map((tool) => (
-                <span
-                  key={tool}
-                  className="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
-                >
-                  {tool}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Contact */}
-      <section>
-        <h2 className="mb-4 text-2xl font-semibold">📫 Contact</h2>
-        <ul className="space-y-2 text-zinc-600 dark:text-zinc-400">
-          <li className="flex items-center gap-2">
-            <span className="font-medium text-zinc-900 dark:text-zinc-100">Email:</span>
-            <a
-              href="mailto:mink906@gmail.com"
-              className="text-blue-600 hover:underline dark:text-blue-400"
-            >
-              mink906@gmail.com
-            </a>
-          </li>
-          <li className="flex items-center gap-2">
-            <span className="font-medium text-zinc-900 dark:text-zinc-100">GitHub:</span>
-            <a
-              href="https://github.com/kmg733"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline dark:text-blue-400"
-            >
-              @kmg733
-            </a>
-          </li>
-        </ul>
-      </section>
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,47 +2,149 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "About",
-  description: "개발자 소개",
+  description: "풀스택 개발자를 꿈꾸는 MinGyu입니다.",
+};
+
+const techStack = {
+  languages: ["Java", "JavaScript", "TypeScript"],
+  frameworks: ["Spring Boot", "Spring Security", "React", "Bootstrap", "Tailwind CSS"],
+  databases: ["PostgreSQL", "MariaDB"],
+  tools: ["Git", "GitHub", "GitLab"],
 };
 
 export default function AboutPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-16">
-      <h1 className="mb-8 text-3xl font-bold">About Me</h1>
-
-      <div className="prose prose-zinc max-w-none dark:prose-invert">
-        <p className="text-lg text-zinc-600 dark:text-zinc-400">
-          안녕하세요! 소프트웨어 개발자입니다.
+      {/* Header */}
+      <header className="mb-12">
+        <h1 className="text-4xl font-bold">
+          👋 Hello! I&apos;m <span className="text-blue-600 dark:text-blue-400">MinGyu</span>
+        </h1>
+        <p className="mt-4 text-xl text-zinc-600 dark:text-zinc-400">
+          🚀 풀스택을 꿈꾸는 개발자
         </p>
-
-        <h2>Skills</h2>
-        <ul>
-          <li>Frontend: React, Next.js, TypeScript</li>
-          <li>Backend: Node.js, Java, Spring</li>
-          <li>Database: PostgreSQL, MySQL, MongoDB</li>
-          <li>DevOps: Docker, AWS, GitHub Actions</li>
+      </header>
+ 
+      {/* About Me */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-semibold">🙋‍♂️ About Me</h2>
+        <ul className="space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li className="flex items-start gap-2">
+            <span>🎯</span>
+            <span>풀스택 개발자가 되기 위해 끊임없이 성장 중</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span>💻</span>
+            <span>백엔드부터 프론트엔드까지 경험을 쌓고 있습니다</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span>📚</span>
+            <span>새로운 기술을 배우고 적용하는 것을 좋아합니다</span>
+          </li>
         </ul>
+      </section>
 
-        <h2>Experience</h2>
-        <p>
-          이곳에 경력 사항을 작성하세요.
-        </p>
+      {/* Tech Stack */}
+      <section className="mb-12">
+        <h2 className="mb-6 text-2xl font-semibold">🛠️ Tech Stack</h2>
 
-        <h2>Contact</h2>
-        <ul>
-          <li>
-            GitHub:{" "}
+        <div className="grid gap-6 sm:grid-cols-2">
+          {/* Languages */}
+          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
+              💬 Languages
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {techStack.languages.map((lang) => (
+                <span
+                  key={lang}
+                  className="rounded-full bg-blue-100 px-3 py-1 text-sm text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                >
+                  {lang}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Frameworks & Libraries */}
+          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
+              🧩 Frameworks & Libraries
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {techStack.frameworks.map((fw) => (
+                <span
+                  key={fw}
+                  className="rounded-full bg-green-100 px-3 py-1 text-sm text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                >
+                  {fw}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Databases */}
+          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
+              🗄️ Databases
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {techStack.databases.map((db) => (
+                <span
+                  key={db}
+                  className="rounded-full bg-orange-100 px-3 py-1 text-sm text-orange-700 dark:bg-orange-900/30 dark:text-orange-300"
+                >
+                  {db}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Tools */}
+          <div className="rounded-lg border border-zinc-200 p-4 dark:border-zinc-800">
+            <h3 className="mb-3 font-semibold text-zinc-900 dark:text-zinc-100">
+              🔧 Tools & Environment
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {techStack.tools.map((tool) => (
+                <span
+                  key={tool}
+                  className="rounded-full bg-purple-100 px-3 py-1 text-sm text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
+                >
+                  {tool}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Contact */}
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold">📫 Contact</h2>
+        <ul className="space-y-2 text-zinc-600 dark:text-zinc-400">
+          <li className="flex items-center gap-2">
+            <span className="font-medium text-zinc-900 dark:text-zinc-100">Email:</span>
+            <a
+              href="mailto:mink906@gmail.com"
+              className="text-blue-600 hover:underline dark:text-blue-400"
+            >
+              mink906@gmail.com
+            </a>
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="font-medium text-zinc-900 dark:text-zinc-100">GitHub:</span>
             <a
               href="https://github.com/kmg733"
               target="_blank"
               rel="noopener noreferrer"
+              className="text-blue-600 hover:underline dark:text-blue-400"
             >
               @kmg733
             </a>
           </li>
-          <li>Email: your-email@example.com</li>
         </ul>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,3 +25,20 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Fade-in animation for About page */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.6s ease-out forwards;
+  opacity: 0;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     default: "Manuel",
     template: "%s | Manuel",
   },
-  description: "Manuel의 포트폴리오 및 기술 블로그",
+  description: "Manuel의 기술 블로그",
 };
 
 export default function RootLayout({

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -9,7 +9,7 @@ export const projectsData: Project[] = [
   {
     id: "1",
     title: "Portfolio & Blog",
-    description: "Next.js와 TypeScript로 만든 Manuel의 포트폴리오 및 블로그 사이트",
+    description: "Next.js와 TypeScript로 만든 Manuel의 블로그 사이트",
     tags: ["Next.js", "TypeScript", "Tailwind CSS"],
     githubUrl: "https://github.com/kmg733/kmg733.github.io",
     demoUrl: "https://kmg733.github.io",


### PR DESCRIPTION
## 📋 변경 사항

### About 페이지 전면 개편
GitHub README 기반으로 About 페이지를 전면 개편했습니다.

**콘텐츠 변경**:
- 자기소개 섹션 추가 (About Me)
- 기술 스택 카드형 레이아웃 적용 (Languages, Frameworks, Databases, Tools)
- 실제 연락처 정보 반영 (mink906@gmail.com)

**UI/UX 개선**:
- 배경에 그라데이션 블러 장식 추가
- 헤더에 그라데이션 배경 및 유리 효과(glassmorphism) 적용
- 이름 텍스트에 그라데이션 색상 적용
- 섹션별 순차적 페이드인 애니메이션
- 카드 hover 시 위로 떠오르는 효과
- 기술 배지 hover 시 확대 및 색상 변화
- 다크모드 완벽 지원

---

## 📂 변경된 파일 (5개)

| 상태 | 파일 |
|------|------|
| ✏️ 수정 | `.gitignore` |
| ✏️ 수정 | `src/app/about/page.tsx` |
| ✏️ 수정 | `src/app/globals.css` |
| ✏️ 수정 | `src/app/layout.tsx` |
| ✏️ 수정 | `src/data/projects.ts` |

---

## 📊 요약
- **커밋 수**: 2개
- **변경된 파일**: 5개

Closes #8