### PR TITLE
fix: About 페이지 접근성 개선 (#12)

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,7 +17,7 @@ export default function AboutPage() {
   return (
     <div className="relative mx-auto max-w-3xl px-4 py-16">
       {/* Background Decorative Elements */}
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
         <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-gradient-to-br from-blue-500/10 to-purple-500/10 blur-3xl dark:from-blue-500/5 dark:to-purple-500/5" />
         <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-gradient-to-tr from-green-500/10 to-blue-500/10 blur-3xl dark:from-green-500/5 dark:to-blue-500/5" />
       </div>
@@ -27,31 +27,31 @@ export default function AboutPage() {
         {/* Header with gradient background */}
         <header className="mb-12 animate-fade-in-up rounded-2xl bg-gradient-to-br from-blue-50 to-indigo-50 p-8 shadow-lg dark:from-blue-950/30 dark:to-indigo-950/30 dark:shadow-blue-900/20">
           <h1 className="text-4xl font-bold md:text-5xl">
-            👋 Hello! I&apos;m{" "}
+            <span role="img" aria-label="손 흔들기">👋</span> Hello! I&apos;m{" "}
             <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent dark:from-blue-400 dark:to-indigo-400">
               MinGyu
             </span>
           </h1>
           <p className="mt-4 text-xl text-zinc-700 dark:text-zinc-300">
-            🚀 풀스택을 꿈꾸는 개발자
+            <span role="img" aria-label="로켓">🚀</span> 풀스택을 꿈꾸는 개발자
           </p>
         </header>
 
         {/* About Me with staggered animation */}
         <section className="mb-12 animate-fade-in-up animate-delay-100">
-          <h2 className="mb-6 text-2xl font-semibold">🙋‍♂️ About Me</h2>
+          <h2 className="mb-6 text-2xl font-semibold"><span role="img" aria-label="자기소개">🙋‍♂️</span> About Me</h2>
           <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
             <ul className="space-y-4 text-zinc-600 dark:text-zinc-400">
               <li className="flex items-start gap-3 transition-transform duration-200 hover:translate-x-1">
-                <span className="text-2xl">🎯</span>
+                <span className="text-2xl" role="img" aria-label="목표">🎯</span>
                 <span className="pt-1">풀스택 개발자가 되기 위해 끊임없이 성장 중</span>
               </li>
               <li className="flex items-start gap-3 transition-transform duration-200 hover:translate-x-1">
-                <span className="text-2xl">💻</span>
+                <span className="text-2xl" role="img" aria-label="컴퓨터">💻</span>
                 <span className="pt-1">백엔드부터 프론트엔드까지 경험을 쌓고 있습니다</span>
               </li>
               <li className="flex items-start gap-3 transition-transform duration-200 hover:translate-x-1">
-                <span className="text-2xl">📚</span>
+                <span className="text-2xl" role="img" aria-label="책">📚</span>
                 <span className="pt-1">새로운 기술을 배우고 적용하는 것을 좋아합니다</span>
               </li>
             </ul>
@@ -60,11 +60,12 @@ export default function AboutPage() {
 
         {/* Tech Stack with enhanced cards */}
         <section className="mb-12 animate-fade-in-up animate-delay-200">
-          <h2 className="mb-6 text-2xl font-semibold">🛠️ Tech Stack</h2>
+          <h2 className="mb-6 text-2xl font-semibold"><span role="img" aria-label="기술 스택">🛠️</span> Tech Stack</h2>
 
           <div className="grid gap-6 sm:grid-cols-2">
             <TechCard
               icon="💬"
+              iconLabel="언어"
               title="Languages"
               items={techStack.languages}
               colorScheme="blue"
@@ -72,6 +73,7 @@ export default function AboutPage() {
 
             <TechCard
               icon="🧩"
+              iconLabel="프레임워크"
               title="Frameworks & Libraries"
               items={techStack.frameworks}
               colorScheme="green"
@@ -79,6 +81,7 @@ export default function AboutPage() {
 
             <TechCard
               icon="🗄️"
+              iconLabel="데이터베이스"
               title="Databases"
               items={techStack.databases}
               colorScheme="orange"
@@ -86,6 +89,7 @@ export default function AboutPage() {
 
             <TechCard
               icon="🔧"
+              iconLabel="도구"
               title="Tools & Environment"
               items={techStack.tools}
               colorScheme="purple"
@@ -95,7 +99,7 @@ export default function AboutPage() {
 
         {/* Contact with enhanced styling */}
         <section className="animate-fade-in-up animate-delay-300">
-          <h2 className="mb-6 text-2xl font-semibold">📫 Contact</h2>
+          <h2 className="mb-6 text-2xl font-semibold"><span role="img" aria-label="연락처">📫</span> Contact</h2>
           <div className="rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm dark:border-zinc-800 dark:bg-zinc-900/50">
             <ul className="space-y-4 text-zinc-600 dark:text-zinc-400">
               <li className="flex items-center gap-3 transition-all duration-200 hover:translate-x-1">

--- a/src/components/TechCard.tsx
+++ b/src/components/TechCard.tsx
@@ -1,5 +1,6 @@
 interface TechCardProps {
   icon: string;
+  iconLabel: string;
   title: string;
   items: string[];
   colorScheme: "blue" | "green" | "orange" | "purple";
@@ -28,13 +29,13 @@ const colorSchemes = {
   },
 };
 
-export default function TechCard({ icon, title, items, colorScheme }: TechCardProps) {
+export default function TechCard({ icon, iconLabel, title, items, colorScheme }: TechCardProps) {
   const colors = colorSchemes[colorScheme];
 
   return (
     <div className="group rounded-xl border border-zinc-200 bg-white/50 p-6 shadow-md backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900/50">
       <h3 className="mb-4 flex items-center gap-2 font-semibold text-zinc-900 dark:text-zinc-100">
-        <span className="text-xl">{icon}</span>
+        <span className="text-xl" role="img" aria-label={iconLabel}>{icon}</span>
         <span>{title}</span>
       </h3>
       <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- About 페이지의 접근성을 개선하여 스크린리더 사용자 경험 향상

## Changes
- 배경 장식 요소에 `aria-hidden="true"` 추가
- 모든 이모지에 `role="img"` 및 한글 `aria-label` 속성 추가
- WCAG 2.1 가이드라인 준수

## Test plan
- [x] 스크린리더로 About 페이지 접근성 테스트
- [x] 장식 요소가 읽히지 않는지 확인
- [x] 이모지가 적절한 레이블로 읽히는지 확인

Closes #12