### PR TITLE
refactor: 하드코딩된 기본값 상수 추출

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import { postService } from "@/lib/container";
 import { extractHeadings } from "@/lib/toc";
+import { DATE_FORMAT } from "@/lib/constants";
 import TableOfContents from "@/components/TableOfContents";
 import type { Metadata } from "next";
 
@@ -50,11 +51,10 @@ export default async function BlogPostPage({ params }: Props) {
               dateTime={post.date}
               className="text-sm text-zinc-500 dark:text-zinc-500"
             >
-              {new Date(post.date).toLocaleDateString("ko-KR", {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
+              {new Date(post.date).toLocaleDateString(
+                DATE_FORMAT.LOCALE,
+                DATE_FORMAT.OPTIONS
+              )}
             </time>
             <h1 className="mt-2 text-3xl font-bold sm:text-4xl">{post.title}</h1>
             <p className="mt-4 text-zinc-600 dark:text-zinc-400">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { postService } from "@/lib/container";
+import { HOME_DEFAULTS, DATE_FORMAT } from "@/lib/constants";
 
 export default function Home() {
-  const recentPosts = postService.getRecentPosts(3);
+  const recentPosts = postService.getRecentPosts(HOME_DEFAULTS.RECENT_POSTS_COUNT);
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-16">
@@ -58,11 +59,10 @@ export default function Home() {
                   </p>
                   <div className="flex items-center gap-4 text-sm text-zinc-500">
                     <time dateTime={post.date}>
-                      {new Date(post.date).toLocaleDateString("ko-KR", {
-                        year: "numeric",
-                        month: "long",
-                        day: "numeric",
-                      })}
+                      {new Date(post.date).toLocaleDateString(
+                        DATE_FORMAT.LOCALE,
+                        DATE_FORMAT.OPTIONS
+                      )}
                     </time>
                     <span>{post.readingTime}</span>
                   </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * 애플리케이션 전역 상수
+ */
+
+// 포스트 관련 상수
+export const POST_DEFAULTS = {
+  DIRECTORY: "content/posts",
+  CATEGORY: "미분류",
+  DESCRIPTION: "",
+  TAGS: [] as readonly string[],
+} as const;
+
+// 홈페이지 관련 상수
+export const HOME_DEFAULTS = {
+  RECENT_POSTS_COUNT: 3,
+} as const;
+
+// 날짜 포맷 관련 상수
+export const DATE_FORMAT = {
+  LOCALE: "ko-KR",
+  OPTIONS: {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  } as const,
+} as const;

--- a/src/repositories/file-post.repository.ts
+++ b/src/repositories/file-post.repository.ts
@@ -4,6 +4,7 @@ import matter from "gray-matter";
 import readingTime from "reading-time";
 import type { IPostRepository } from "@/interfaces";
 import type { Post, PostMeta, PostFrontmatter } from "@/types";
+import { POST_DEFAULTS } from "@/lib/constants";
 
 /**
  * 파일 시스템 기반 포스트 Repository 구현체 (Infrastructure Layer)
@@ -16,7 +17,7 @@ export class FilePostRepository implements IPostRepository {
 
   constructor(postsDirectory?: string) {
     this.postsDirectory =
-      postsDirectory ?? path.join(process.cwd(), "content/posts");
+      postsDirectory ?? path.join(process.cwd(), POST_DEFAULTS.DIRECTORY);
   }
 
   findAll(): PostMeta[] {
@@ -115,10 +116,10 @@ export class FilePostRepository implements IPostRepository {
       slug,
       title: frontmatter.title ?? slug,
       date: frontmatter.date ?? new Date().toISOString(),
-      description: frontmatter.description ?? "",
-      category: frontmatter.category ?? "미분류",
+      description: frontmatter.description ?? POST_DEFAULTS.DESCRIPTION,
+      category: frontmatter.category ?? POST_DEFAULTS.CATEGORY,
       subcategory: frontmatter.subcategory,
-      tags: frontmatter.tags ?? [],
+      tags: frontmatter.tags ?? [...POST_DEFAULTS.TAGS],
       readingTime: stats.text,
     };
   }


### PR DESCRIPTION
## Summary
- 하드코딩된 기본값들을 `src/lib/constants.ts` 파일로 추출
- 코드 유지보수성 및 일관성 향상

## 변경 사항

### 추출된 상수
| 상수 | 값 | 용도 |
|------|-----|------|
| `POST_DEFAULTS.DIRECTORY` | `"content/posts"` | 포스트 디렉토리 경로 |
| `POST_DEFAULTS.CATEGORY` | `"미분류"` | 기본 카테고리 |
| `POST_DEFAULTS.DESCRIPTION` | `""` | 기본 설명 |
| `POST_DEFAULTS.TAGS` | `[]` | 기본 태그 |
| `HOME_DEFAULTS.RECENT_POSTS_COUNT` | `3` | 홈페이지 최근 포스트 수 |
| `DATE_FORMAT.LOCALE` | `"ko-KR"` | 날짜 로케일 |
| `DATE_FORMAT.OPTIONS` | `{year, month, day}` | 날짜 포맷 옵션 |

### 수정된 파일
- `src/lib/constants.ts` - 상수 정의 파일 (신규)
- `src/repositories/file-post.repository.ts` - 포스트 기본값 상수 적용
- `src/app/page.tsx` - 최근 포스트 수, 날짜 포맷 상수 적용
- `src/app/blog/[slug]/page.tsx` - 날짜 포맷 상수 적용

## Test plan
- [x] `npm run build` 성공 확인\

closes #21 