### PR TITLE
feat: 이미지 클릭 시 확대/축소 기능 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -274,89 +274,91 @@ body::before {
    Image Lightbox Styles
    ======================================== */
 
-/* 이미지에 클릭 가능 표시 */
-.prose img {
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+@layer components {
+  /* 이미지에 클릭 가능 표시 */
+  .prose img {
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .prose img:hover {
+    transform: scale(1.02);
+    box-shadow: 0 8px 25px -5px rgb(0 0 0 / 0.15);
+  }
+
+  .dark .prose img:hover {
+    box-shadow: 0 8px 25px -5px rgb(0 0 0 / 0.4);
+  }
+
+  /* 라이트박스 오버레이 */
+  .lightbox-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(4px);
+    animation: lightbox-fade-in 0.25s ease-out;
+  }
+
+  .dark .lightbox-overlay {
+    background-color: rgba(0, 0, 0, 0.92);
+  }
+
+  /* 닫기 버튼 */
+  .lightbox-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    background-color: rgba(255, 255, 255, 0.1);
+    border: none;
+    border-radius: 50%;
+    color: white;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .lightbox-close:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+    transform: scale(1.1);
+  }
+
+  .lightbox-close:focus {
+    outline: 2px solid rgba(255, 255, 255, 0.5);
+    outline-offset: 2px;
+  }
+
+  /* 이미지 컨테이너 */
+  .lightbox-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    max-width: 90vw;
+    max-height: 90vh;
+    animation: lightbox-scale-in 0.3s ease-out;
+  }
+
+  /* 확대된 이미지 */
+  .lightbox-image {
+    max-width: 100%;
+    max-height: 90vh;
+    object-fit: contain;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5);
+  }
 }
 
-.prose img:hover {
-  transform: scale(1.02);
-  box-shadow: 0 8px 25px -5px rgb(0 0 0 / 0.15);
-}
-
-.dark .prose img:hover {
-  box-shadow: 0 8px 25px -5px rgb(0 0 0 / 0.4);
-}
-
-/* 라이트박스 오버레이 */
-.lightbox-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(0, 0, 0, 0.85);
-  backdrop-filter: blur(4px);
-  animation: lightbox-fade-in 0.25s ease-out;
-}
-
-.dark .lightbox-overlay {
-  background-color: rgba(0, 0, 0, 0.92);
-}
-
-/* 닫기 버튼 */
-.lightbox-close {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  background-color: rgba(255, 255, 255, 0.1);
-  border: none;
-  border-radius: 50%;
-  color: white;
-  cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-.lightbox-close:hover {
-  background-color: rgba(255, 255, 255, 0.2);
-  transform: scale(1.1);
-}
-
-.lightbox-close:focus {
-  outline: 2px solid rgba(255, 255, 255, 0.5);
-  outline-offset: 2px;
-}
-
-/* 이미지 컨테이너 */
-.lightbox-content {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 90vw;
-  max-height: 90vh;
-  animation: lightbox-scale-in 0.3s ease-out;
-}
-
-/* 확대된 이미지 */
-.lightbox-image {
-  max-width: 100%;
-  max-height: 90vh;
-  object-fit: contain;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5);
-}
-
-/* 애니메이션 */
+/* 애니메이션 - @layer 밖에 정의 (keyframes는 layer 영향 없음) */
 @keyframes lightbox-fade-in {
   from {
     opacity: 0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -269,3 +269,110 @@ body::before {
 .dark .heading-highlight {
   animation: heading-flash-dark 1.5s ease-in-out;
 }
+
+/* ========================================
+   Image Lightbox Styles
+   ======================================== */
+
+/* 이미지에 클릭 가능 표시 */
+.prose img {
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.prose img:hover {
+  transform: scale(1.02);
+  box-shadow: 0 8px 25px -5px rgb(0 0 0 / 0.15);
+}
+
+.dark .prose img:hover {
+  box-shadow: 0 8px 25px -5px rgb(0 0 0 / 0.4);
+}
+
+/* 라이트박스 오버레이 */
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(4px);
+  animation: lightbox-fade-in 0.25s ease-out;
+}
+
+.dark .lightbox-overlay {
+  background-color: rgba(0, 0, 0, 0.92);
+}
+
+/* 닫기 버튼 */
+.lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  background-color: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 50%;
+  color: white;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.lightbox-close:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  transform: scale(1.1);
+}
+
+.lightbox-close:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
+}
+
+/* 이미지 컨테이너 */
+.lightbox-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 90vw;
+  max-height: 90vh;
+  animation: lightbox-scale-in 0.3s ease-out;
+}
+
+/* 확대된 이미지 */
+.lightbox-image {
+  max-width: 100%;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5);
+}
+
+/* 애니메이션 */
+@keyframes lightbox-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes lightbox-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Sacramento } from "next/font/google";
 import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
+import ImageLightbox from "@/components/ImageLightbox";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -74,6 +75,8 @@ export default function RootLayout({
         </header>
 
         <main className="flex-1">{children}</main>
+
+        <ImageLightbox />
 
         <footer className="border-t border-zinc-200 py-8 dark:border-zinc-800">
           <div className="mx-auto max-w-4xl px-4 text-center text-sm text-zinc-500">

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+export default function ImageLightbox() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [imageAlt, setImageAlt] = useState("");
+  const [mounted, setMounted] = useState(false);
+
+  // Hydration 완료 후 마운트
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // 라이트박스 닫기
+  const closeLightbox = useCallback(() => {
+    setIsOpen(false);
+    setImageSrc(null);
+    setImageAlt("");
+  }, []);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        closeLightbox();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      // 스크롤 방지
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, closeLightbox]);
+
+  // 이미지 클릭 이벤트 위임
+  useEffect(() => {
+    const handleImageClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+
+      // .prose 내부의 img 요소만 처리
+      if (
+        target.tagName === "IMG" &&
+        target.closest(".prose") &&
+        !target.closest(".lightbox-overlay")
+      ) {
+        const img = target as HTMLImageElement;
+        setImageSrc(img.src);
+        setImageAlt(img.alt || "");
+        setIsOpen(true);
+      }
+    };
+
+    document.addEventListener("click", handleImageClick);
+    return () => document.removeEventListener("click", handleImageClick);
+  }, []);
+
+  // 서버 렌더링 시 또는 닫혀있을 때 렌더링하지 않음
+  if (!mounted || !isOpen || !imageSrc) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="lightbox-overlay"
+      onClick={closeLightbox}
+      role="dialog"
+      aria-modal="true"
+      aria-label={imageAlt || "확대된 이미지"}
+    >
+      {/* 닫기 버튼 */}
+      <button
+        className="lightbox-close"
+        onClick={closeLightbox}
+        aria-label="이미지 닫기"
+        type="button"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+
+      {/* 확대된 이미지 */}
+      <div className="lightbox-content" onClick={(e) => e.stopPropagation()}>
+        <img
+          src={imageSrc}
+          alt={imageAlt}
+          className="lightbox-image"
+          onClick={closeLightbox}
+        />
+      </div>
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
## Summary
- 블로그 포스트 내 이미지 클릭 시 라이트박스 형태로 확대 표시
- ESC 키, 배경/이미지 클릭으로 닫기 지원
- 다크 모드 호환 및 부드러운 애니메이션 효과 적용

## 변경사항
- `src/components/ImageLightbox.tsx` (신규): 라이트박스 모달 컴포넌트
- `src/app/globals.css`: 라이트박스 스타일/애니메이션 추가 (@layer components)
- `src/app/layout.tsx`: ImageLightbox 컴포넌트 통합

## 관련 이슈
Closes #34

## Test plan
- [x] 블로그 포스트 페이지에서 이미지 클릭 시 라이트박스 열림 확인
- [x] 배경 클릭 시 닫힘 확인
- [x] 이미지 클릭 시 닫힘 확인
- [x] ESC 키 입력 시 닫힘 확인
- [x] X 버튼 클릭 시 닫힘 확인
- [x] 라이트 모드에서 정상 동작 확인
- [x] 다크 모드에서 정상 동작 확인