### PR TITLE
feat: 라이트박스 닫기 애니메이션 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -376,6 +376,15 @@ body::before {
     cursor: pointer;
     box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5);
   }
+
+  /* 닫기 애니메이션 */
+  .lightbox-overlay.closing {
+    animation: lightbox-fade-out 0.25s ease-out forwards;
+  }
+
+  .lightbox-content.closing {
+    animation: lightbox-scale-out 0.25s ease-out forwards;
+  }
 }
 
 /* 애니메이션 - @layer 밖에 정의 (keyframes는 layer 영향 없음) */
@@ -388,6 +397,15 @@ body::before {
   }
 }
 
+@keyframes lightbox-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 @keyframes lightbox-scale-in {
   from {
     opacity: 0;
@@ -396,5 +414,16 @@ body::before {
   to {
     opacity: 1;
     transform: scale(1);
+  }
+}
+
+@keyframes lightbox-scale-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.9);
   }
 }

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 
 export default function ImageLightbox() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [imageAlt, setImageAlt] = useState("");
   const [mounted, setMounted] = useState(false);
@@ -14,12 +15,21 @@ export default function ImageLightbox() {
     setMounted(true);
   }, []);
 
-  // 라이트박스 닫기
+  // 라이트박스 닫기 애니메이션 시작
   const closeLightbox = useCallback(() => {
-    setIsOpen(false);
-    setImageSrc(null);
-    setImageAlt("");
-  }, []);
+    if (isClosing) return; // 이미 닫기 중이면 무시
+    setIsClosing(true);
+  }, [isClosing]);
+
+  // 애니메이션 완료 후 실제로 닫기
+  const handleAnimationEnd = useCallback(() => {
+    if (isClosing) {
+      setIsOpen(false);
+      setImageSrc(null);
+      setImageAlt("");
+      setIsClosing(false);
+    }
+  }, [isClosing]);
 
   // ESC 키로 닫기
   useEffect(() => {
@@ -70,8 +80,9 @@ export default function ImageLightbox() {
 
   return createPortal(
     <div
-      className="lightbox-overlay"
+      className={`lightbox-overlay${isClosing ? " closing" : ""}`}
       onClick={closeLightbox}
+      onAnimationEnd={handleAnimationEnd}
       role="dialog"
       aria-modal="true"
       aria-label={imageAlt || "확대된 이미지"}
@@ -100,7 +111,10 @@ export default function ImageLightbox() {
       </button>
 
       {/* 확대된 이미지 */}
-      <div className="lightbox-content" onClick={(e) => e.stopPropagation()}>
+      <div
+        className={`lightbox-content${isClosing ? " closing" : ""}`}
+        onClick={(e) => e.stopPropagation()}
+      >
         <img
           src={imageSrc}
           alt={imageAlt}


### PR DESCRIPTION
Closes #38 

## Summary
- 라이트박스 닫기 시 부드러운 fade-out 및 scale-down 애니메이션 적용
- ESC 키, 닫기 버튼, 배경/이미지 클릭 모두 동일한 애니메이션 동작
- 연속 클릭 방지 처리로 안정성 확보

## Test plan
- [x] 이미지 클릭하여 라이트박스 열기
- [ ] 닫기 버튼 클릭 시 부드럽게 fade-out 확인
- [ ] ESC 키로 닫을 때 부드럽게 fade-out 확인
- [ ] 배경 클릭 시 부드럽게 fade-out 확인
- [ ] 이미지 클릭 시 부드럽게 fade-out 확인
- [ ] 다크 모드에서 동일하게 동작 확인