### PR TITLE
fix: 라이트박스 열기 직후 닫히는 버그 수정 (#40)

### DIFF
--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -22,14 +22,18 @@ export default function ImageLightbox() {
   }, [isClosing]);
 
   // 애니메이션 완료 후 실제로 닫기
-  const handleAnimationEnd = useCallback(() => {
-    if (isClosing) {
-      setIsOpen(false);
-      setImageSrc(null);
-      setImageAlt("");
-      setIsClosing(false);
-    }
-  }, [isClosing]);
+  const handleAnimationEnd = useCallback(
+    (e: React.AnimationEvent<HTMLDivElement>) => {
+      // 닫기 애니메이션(lightbox-fade-out)일 때만 처리
+      if (e.animationName === "lightbox-fade-out") {
+        setIsOpen(false);
+        setImageSrc(null);
+        setImageAlt("");
+        setIsClosing(false);
+      }
+    },
+    []
+  );
 
   // ESC 키로 닫기
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `onAnimationEnd`에서 애니메이션 이름을 확인하여 `lightbox-fade-out`일 때만 닫기 처리
- 열기 애니메이션(`lightbox-fade-in`)이 닫기를 트리거하는 문제 해결

## 변경 내용
```typescript
// Before
const handleAnimationEnd = useCallback(() => {
  if (isClosing) { ... }
}, [isClosing]);

// After  
const handleAnimationEnd = useCallback((e: React.AnimationEvent) => {
  if (e.animationName === "lightbox-fade-out") { ... }
}, []);
```

## Test plan
- [x] 이미지 클릭하여 라이트박스 열기
- [x] 라이트박스가 열린 상태로 유지되는지 확인
- [x] 닫기 버튼/ESC/배경 클릭 시 부드럽게 닫히는지 확인

Closes #40