### PR TITLE
feat: 라이트박스 이미지 로딩 스피너 추가 (#42)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -375,6 +375,32 @@ body::before {
     border-radius: 0.5rem;
     cursor: pointer;
     box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5);
+    transition: opacity 0.3s ease;
+  }
+
+  /* 이미지 로딩 상태 */
+  .lightbox-image.loading {
+    opacity: 0;
+  }
+
+  .lightbox-image.loaded {
+    opacity: 1;
+  }
+
+  /* 로딩 스피너 */
+  .lightbox-spinner {
+    position: absolute;
+    width: 48px;
+    height: 48px;
+    border: 4px solid rgba(251, 191, 36, 0.3);
+    border-top-color: #fbbf24;
+    border-radius: 50%;
+    animation: lightbox-spinner-spin 1s linear infinite;
+  }
+
+  .dark .lightbox-spinner {
+    border-color: rgba(148, 163, 184, 0.3);
+    border-top-color: #94a3b8;
   }
 
   /* 닫기 애니메이션 */
@@ -425,5 +451,14 @@ body::before {
   to {
     opacity: 0;
     transform: scale(0.9);
+  }
+}
+
+@keyframes lightbox-spinner-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 export default function ImageLightbox() {
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [imageAlt, setImageAlt] = useState("");
   const [mounted, setMounted] = useState(false);
@@ -30,10 +31,21 @@ export default function ImageLightbox() {
         setImageSrc(null);
         setImageAlt("");
         setIsClosing(false);
+        setIsLoading(true); // 다음 열기를 위해 로딩 상태 리셋
       }
     },
     []
   );
+
+  // 이미지 로딩 완료 핸들러
+  const handleImageLoad = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  // 이미지 로딩 실패 핸들러
+  const handleImageError = useCallback(() => {
+    setIsLoading(false);
+  }, []);
 
   // ESC 키로 닫기
   useEffect(() => {
@@ -69,6 +81,7 @@ export default function ImageLightbox() {
         const img = target as HTMLImageElement;
         setImageSrc(img.src);
         setImageAlt(img.alt || "");
+        setIsLoading(true); // 라이트박스 열 때 로딩 상태 초기화
         setIsOpen(true);
       }
     };
@@ -119,11 +132,21 @@ export default function ImageLightbox() {
         className={`lightbox-content${isClosing ? " closing" : ""}`}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* 로딩 스피너 */}
+        {isLoading && (
+          <div
+            className="lightbox-spinner"
+            role="status"
+            aria-label="이미지 로딩 중"
+          />
+        )}
         <img
           src={imageSrc}
           alt={imageAlt}
-          className="lightbox-image"
+          className={`lightbox-image${isLoading ? " loading" : " loaded"}`}
           onClick={closeLightbox}
+          onLoad={handleImageLoad}
+          onError={handleImageError}
         />
       </div>
     </div>,


### PR DESCRIPTION
## 개요
라이트박스에서 이미지가 로딩되는 동안 사용자에게 시각적 피드백을 제공하는 스피너(로딩 인디케이터)를 추가했습니다.

---

## 주요 변경사항

### 새로운 기능
- **로딩 스피너 표시**: 라이트박스 열릴 때 이미지 로딩 전까지 회전 스피너 표시
- **부드러운 전환**: 이미지 로딩 완료 시 fade-in 효과로 자연스럽게 표시
- **다크 모드 지원**: 라이트 모드(amber), 다크 모드(slate) 색상 적용

### 접근성
- `role="status"` 및 `aria-label="이미지 로딩 중"` 추가

---

## 수정된 파일 목록
- `src/components/ImageLightbox.tsx` - 로딩 상태 관리, 스피너 JSX 추가
- `src/app/globals.css` - 스피너 스타일 및 애니메이션 추가

## 테스트
- [x] 라이트박스 열기 → 스피너 표시 확인
- [x] 이미지 로딩 완료 → 스피너 사라지고 이미지 표시 확인
- [x] 다크 모드 전환 → 스피너 색상 변경 확인
- [x] ESC/클릭으로 닫기 → 정상 동작 확인
- [x] 다시 열기 → 스피너 다시 표시 확인
- [x] 빌드 성공 확인

---

Closes #36 