### PR TITLE
fix: favicon 선택자 고유 ID 적용 (#45)

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -61,12 +61,13 @@ export default function ThemeToggle() {
   const updateFavicon = (newTheme: "light" | "dark") => {
     const faviconUrl = newTheme === "dark" ? "/icon-dark.svg" : "/icon-light.svg";
 
-    // 기존 favicon link 요소 찾기
-    let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    // 고유 ID로 특정 favicon link 요소만 선택
+    let link = document.querySelector<HTMLLinkElement>("link#theme-favicon");
 
     if (!link) {
       // 없으면 새로 생성
       link = document.createElement("link");
+      link.id = "theme-favicon";
       link.rel = "icon";
       link.type = "image/svg+xml";
       document.head.appendChild(link);


### PR DESCRIPTION
## 개요
`document.querySelector('link[rel="icon"]')`가 첫 번째 매칭 요소만 반환하는 문제를 수정했습니다.

---

## 문제점
여러 `<link rel="icon">` 요소가 있을 경우 잘못된 DOM을 선택할 수 있음

## 해결 방법
고유 ID(`#theme-favicon`)를 사용하여 특정 요소만 선택

```tsx
// Before
let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');

// After
let link = document.querySelector<HTMLLinkElement>("link#theme-favicon");
```

---

## 수정된 파일
- `src/components/ThemeToggle.tsx` - 선택자 변경 및 ID 추가

## 테스트
- [x] 테마 토글 시 favicon 정상 변경 확인
- [x] 빌드 성공 확인

---

Closes #45