### PR TITLE
fix: 라이트박스 포커스 트랩 개선 및 빌드 에러 수정 (#37, #50)

### DIFF
--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -105,6 +105,8 @@ export function useFocusTrap(
 
       if (event.key !== "Tab") return;
 
+      if (!container) return;
+
       const focusableElements = queryFocusableElements(container);
       if (focusableElements.length === 0) {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- 라이트박스 키보드 포커스 트랩 기능 추가 및 안정화 (#37)
- `useFocusTrap` 클로저 내 container null 체크 누락으로 인한 빌드 실패 수정 (#50)

## Changes

### #37 라이트박스 포커스 트랩
- `useFocusTrap` 훅 구현 (Tab/Shift+Tab 순환, Escape 닫기)
- document 레벨 capture 단계 이벤트 처리
- 포커스 가능 요소가 1개일 때 처리
- keyframes를 `@layer` 내부로 이동하여 animationend 이벤트 정상 동작
- 닫기 버튼 `focus-visible` 스타일 개선

### #50 빌드 에러 수정
- `handleKeyDown` 클로저 내부에 `container` null 가드 추가
- TypeScript가 클로저 캡처 변수의 non-null을 보장하지 못하는 문제 해결

## Test plan
- [x] 라이트박스 열림 시 포커스가 닫기 버튼으로 이동하는지 확인
- [x] Tab/Shift+Tab으로 포커스가 라이트박스 내부에서 순환하는지 확인
- [x] Escape 키로 라이트박스가 닫히는지 확인
- [x] `next build` 성공 확인

Closes #37, #50