### PR TITLE
feat: 추천/연관 글 목록 기능 추가

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { postService } from "@/lib/container";
 import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";
 import TableOfContents from "@/components/TableOfContents";
+import RelatedPosts from "@/components/RelatedPosts";
 import type { Metadata } from "next";
 
 interface Props {
@@ -40,6 +41,7 @@ export default async function BlogPostPage({ params }: Props) {
   }
 
   const headings = extractHeadings(post.content);
+  const relatedPosts = postService.getRelatedPosts(slug, 3);
 
   return (
     <div className="relative mx-auto max-w-6xl px-4 py-16">
@@ -84,6 +86,8 @@ export default async function BlogPostPage({ params }: Props) {
               }}
             />
           </div>
+
+          <RelatedPosts posts={relatedPosts} />
         </article>
 
         {/* 우측 목차 영역 */}

--- a/src/components/RelatedPosts.tsx
+++ b/src/components/RelatedPosts.tsx
@@ -1,0 +1,48 @@
+import type { PostMeta } from "@/types";
+import { DATE_FORMAT } from "@/lib/constants";
+
+interface RelatedPostsProps {
+  posts: PostMeta[];
+}
+
+const RelatedPosts: React.FC<RelatedPostsProps> = ({ posts }) => {
+  if (posts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-12 border-t border-zinc-200 pt-8 dark:border-zinc-700">
+      <h2 className="mb-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+        관련 글
+      </h2>
+      <div className="grid gap-6 md:grid-cols-3">
+        {posts.map((post) => {
+          const formattedDate = new Date(post.date).toLocaleDateString(
+            DATE_FORMAT.LOCALE,
+            DATE_FORMAT.OPTIONS as Intl.DateTimeFormatOptions
+          );
+
+          return (
+            <a
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              className="group rounded-lg border border-zinc-200 bg-white p-6 shadow-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800"
+            >
+              <h3 className="mb-2 text-lg font-semibold text-zinc-900 group-hover:text-amber-600 dark:text-zinc-100 dark:group-hover:text-amber-400">
+                {post.title}
+              </h3>
+              <p className="mb-3 text-sm text-zinc-600 dark:text-zinc-400">
+                {post.description}
+              </p>
+              <time className="text-xs text-zinc-500 dark:text-zinc-500">
+                {formattedDate}
+              </time>
+            </a>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default RelatedPosts;

--- a/src/components/__tests__/RelatedPosts.test.tsx
+++ b/src/components/__tests__/RelatedPosts.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import RelatedPosts from "../RelatedPosts";
+import type { PostMeta } from "@/types";
+
+function createPostMeta(overrides: Partial<PostMeta> = {}): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-15",
+    description: "Test description",
+    category: "dev",
+    tags: ["javascript"],
+    readingTime: "5 min read",
+    ...overrides,
+  };
+}
+
+describe("RelatedPosts", () => {
+  it("추천 글이 있을 때 목록을 렌더링한다", () => {
+    const posts = [
+      createPostMeta({ slug: "post-1", title: "First Post" }),
+      createPostMeta({ slug: "post-2", title: "Second Post" }),
+    ];
+
+    render(<RelatedPosts posts={posts} />);
+
+    expect(screen.getByText("관련 글")).toBeInTheDocument();
+    expect(screen.getByText("First Post")).toBeInTheDocument();
+    expect(screen.getByText("Second Post")).toBeInTheDocument();
+  });
+
+  it("각 항목에 제목, 설명, 날짜가 표시된다", () => {
+    const posts = [
+      createPostMeta({
+        slug: "test",
+        title: "Test Title",
+        description: "Test Desc",
+        date: "2025-06-15",
+      }),
+    ];
+
+    render(<RelatedPosts posts={posts} />);
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Test Desc")).toBeInTheDocument();
+  });
+
+  it("각 항목의 링크가 /blog/{slug}로 연결된다", () => {
+    const posts = [
+      createPostMeta({ slug: "my-post", title: "My Post" }),
+    ];
+
+    render(<RelatedPosts posts={posts} />);
+
+    const link = screen.getByRole("link", { name: /My Post/i });
+    expect(link).toHaveAttribute("href", "/blog/my-post");
+  });
+
+  it("빈 배열일 때 아무것도 렌더링하지 않는다", () => {
+    const { container } = render(<RelatedPosts posts={[]} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/lib/__tests__/related-posts.test.ts
+++ b/src/lib/__tests__/related-posts.test.ts
@@ -1,0 +1,126 @@
+import { calculateRelevanceScore } from "../related-posts";
+import type { PostMeta } from "@/types";
+
+function createPostMeta(
+  overrides: Partial<PostMeta> = {}
+): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-01",
+    description: "Test description",
+    category: "dev",
+    tags: ["javascript"],
+    readingTime: "5 min read",
+    ...overrides,
+  };
+}
+
+describe("calculateRelevanceScore", () => {
+  const currentPost = createPostMeta({
+    slug: "current",
+    category: "dev",
+    subcategory: "frontend",
+    tags: ["javascript", "react", "nextjs"],
+  });
+
+  it("같은 subcategory일 때 +3점", () => {
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "other",
+      subcategory: "frontend",
+      tags: [],
+    });
+
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(3);
+  });
+
+  it("같은 category일 때 +2점", () => {
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "dev",
+      subcategory: "backend",
+      tags: [],
+    });
+
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(2);
+  });
+
+  it("공통 tag 1개당 +1점", () => {
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "other",
+      tags: ["javascript", "react"],
+    });
+
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(2);
+  });
+
+  it("모든 조건이 다를 때 0점", () => {
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "life",
+      subcategory: "travel",
+      tags: ["python"],
+    });
+
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(0);
+  });
+
+  it("복합 조건: 같은 category(+2) + 같은 subcategory(+3) + 공통 tag 2개(+2) = 7점", () => {
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "dev",
+      subcategory: "frontend",
+      tags: ["javascript", "react", "typescript"],
+    });
+
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(7);
+  });
+
+  it("currentPost의 subcategory가 undefined이면 subcategory 점수 0점", () => {
+    const noSubcategoryCurrent = createPostMeta({
+      slug: "current",
+      category: "dev",
+      subcategory: undefined,
+      tags: [],
+    });
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "dev",
+      subcategory: "frontend",
+      tags: [],
+    });
+
+    expect(calculateRelevanceScore(noSubcategoryCurrent, candidate)).toBe(2);
+  });
+
+  it("candidate의 subcategory가 undefined이면 subcategory 점수 0점", () => {
+    const candidate = createPostMeta({
+      slug: "candidate",
+      category: "dev",
+      subcategory: undefined,
+      tags: [],
+    });
+
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(2);
+  });
+
+  it("양쪽 subcategory가 undefined이면 subcategory 매칭 안 함", () => {
+    const noSub1 = createPostMeta({
+      slug: "a",
+      category: "other",
+      subcategory: undefined,
+      tags: [],
+    });
+    const noSub2 = createPostMeta({
+      slug: "b",
+      category: "other",
+      subcategory: undefined,
+      tags: [],
+    });
+
+    // category만 일치 = 2점, undefined끼리 매칭하면 안 됨
+    expect(calculateRelevanceScore(noSub1, noSub2)).toBe(2);
+  });
+});

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -1,0 +1,39 @@
+import type { PostMeta } from "@/types";
+
+const SUBCATEGORY_SCORE = 3;
+const CATEGORY_SCORE = 2;
+const TAG_SCORE = 1;
+
+/**
+ * 두 포스트 간 관련도 점수를 계산한다.
+ *
+ * 점수 기준:
+ * - 같은 subcategory: +3
+ * - 같은 category: +2
+ * - 공통 tag 1개당: +1
+ */
+export function calculateRelevanceScore(
+  current: PostMeta,
+  candidate: PostMeta
+): number {
+  let score = 0;
+
+  if (
+    current.subcategory &&
+    candidate.subcategory &&
+    current.subcategory === candidate.subcategory
+  ) {
+    score += SUBCATEGORY_SCORE;
+  }
+
+  if (current.category === candidate.category) {
+    score += CATEGORY_SCORE;
+  }
+
+  const commonTags = current.tags.filter((tag) =>
+    candidate.tags.includes(tag)
+  );
+  score += commonTags.length * TAG_SCORE;
+
+  return score;
+}

--- a/src/services/__tests__/post.service.test.ts
+++ b/src/services/__tests__/post.service.test.ts
@@ -1,0 +1,181 @@
+import { PostService } from "../post.service";
+import type { IPostRepository } from "@/interfaces";
+import type { Post, PostMeta } from "@/types";
+
+function createPostMeta(overrides: Partial<PostMeta> = {}): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-01",
+    description: "Test description",
+    category: "dev",
+    tags: ["javascript"],
+    readingTime: "5 min read",
+    ...overrides,
+  };
+}
+
+function createPost(overrides: Partial<Post> = {}): Post {
+  return {
+    ...createPostMeta(overrides),
+    content: "test content",
+    ...overrides,
+  };
+}
+
+describe("PostService.getRelatedPosts", () => {
+  let mockRepository: jest.Mocked<IPostRepository>;
+  let service: PostService;
+
+  beforeEach(() => {
+    mockRepository = {
+      findAll: jest.fn(),
+      findBySlug: jest.fn(),
+      findAllSlugs: jest.fn(),
+    };
+    service = new PostService(mockRepository);
+  });
+
+  it("관련 글이 있을 때 점수 내림차순으로 반환한다", () => {
+    const currentPost = createPost({
+      slug: "current",
+      category: "dev",
+      subcategory: "frontend",
+      tags: ["react", "nextjs"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react", "nextjs"] }),
+      createPostMeta({ slug: "high-score", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-03" }),  // sub(3) + cat(2) + tag(1) = 6
+      createPostMeta({ slug: "mid-score", category: "dev", subcategory: "backend", tags: ["nextjs"], date: "2025-01-02" }),   // cat(2) + tag(1) = 3
+      createPostMeta({ slug: "low-score", category: "life", tags: ["react"], date: "2025-01-01" }),                            // tag(1) = 1
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("current", 3);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].slug).toBe("high-score");
+    expect(result[1].slug).toBe("mid-score");
+    expect(result[2].slug).toBe("low-score");
+  });
+
+  it("현재 글은 결과에서 제외된다", () => {
+    const currentPost = createPost({
+      slug: "current",
+      category: "dev",
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "current", category: "dev", tags: ["react"] }),
+      createPostMeta({ slug: "other", category: "dev", tags: ["react"] }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("current", 5);
+
+    expect(result.every((p) => p.slug !== "current")).toBe(true);
+    expect(result).toHaveLength(1);
+  });
+
+  it("maxCount 이하로 반환한다", () => {
+    const currentPost = createPost({
+      slug: "current",
+      category: "dev",
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "current", category: "dev", tags: ["react"] }),
+      createPostMeta({ slug: "a", category: "dev", tags: ["react"], date: "2025-01-03" }),
+      createPostMeta({ slug: "b", category: "dev", tags: ["react"], date: "2025-01-02" }),
+      createPostMeta({ slug: "c", category: "dev", tags: ["react"], date: "2025-01-01" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("current", 2);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("점수가 동일하면 날짜 내림차순(최신 우선)으로 정렬한다", () => {
+    const currentPost = createPost({
+      slug: "current",
+      category: "dev",
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "current", category: "dev", tags: ["react"] }),
+      createPostMeta({ slug: "older", category: "dev", tags: ["react"], date: "2025-01-01" }),
+      createPostMeta({ slug: "newer", category: "dev", tags: ["react"], date: "2025-06-01" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("current", 5);
+
+    expect(result[0].slug).toBe("newer");
+    expect(result[1].slug).toBe("older");
+  });
+
+  it("관련 글이 없을 때(점수 0점만) 최신 글 fallback", () => {
+    const currentPost = createPost({
+      slug: "current",
+      category: "dev",
+      subcategory: "frontend",
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react"] }),
+      createPostMeta({ slug: "unrelated-new", category: "life", tags: ["travel"], date: "2025-06-01" }),
+      createPostMeta({ slug: "unrelated-old", category: "life", tags: ["food"], date: "2025-01-01" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("current", 3);
+
+    // fallback: 최신 글 순서
+    expect(result).toHaveLength(2);
+    expect(result[0].slug).toBe("unrelated-new");
+    expect(result[1].slug).toBe("unrelated-old");
+  });
+
+  it("존재하지 않는 slug일 때 빈 배열 반환", () => {
+    mockRepository.findBySlug.mockReturnValue(null);
+
+    const result = service.getRelatedPosts("nonexistent", 3);
+
+    expect(result).toEqual([]);
+  });
+
+  it("포스트가 현재 글 1개뿐이면 빈 배열 반환", () => {
+    const currentPost = createPost({
+      slug: "only-post",
+      category: "dev",
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "only-post", category: "dev", tags: ["react"] }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("only-post", 3);
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 개요
블로그 글 하단에 category/subcategory/tags 기반 점수화로 관련 글을 추천하는 기능 추가

Closes #48

## 주요 변경사항
- `calculateRelevanceScore()` 순수 함수로 점수 계산 로직 분리
  - 같은 subcategory: +3점, 같은 category: +2점, 공통 tag: +1점/개
- `PostService.getRelatedPosts()` 메서드 추가
  - 점수 내림차순 정렬, 동점시 최신 글 우선
  - 관련 글 없을 시 최신 글 fallback
- `RelatedPosts` 컴포넌트 생성 및 블로그 상세 페이지 통합
  - 반응형 3열 그리드, zinc/amber 컬러 스킴, dark mode 지원

## 신규 파일
| 파일 | 설명 |
|------|------|
| `src/lib/related-posts.ts` | 점수 계산 순수 함수 |
| `src/components/RelatedPosts.tsx` | 추천 글 UI 컴포넌트 |

## 수정 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/services/post.service.ts` | `getRelatedPosts()` 메서드 추가 |
| `src/app/blog/[slug]/page.tsx` | RelatedPosts 컴포넌트 통합 |

## 테스트
- [x] 점수 계산 단위 테스트 8개 통과
- [x] PostService 단위 테스트 7개 통과
- [x] RelatedPosts 컴포넌트 테스트 4개 통과
- [x] 전체 테스트 171개 통과 (`npm test`)
- [x] 빌드 성공 (`next build`)
- [x] 린트 확인 (신규 에러 없음)