### PR TITLE
feat: 글로벌 검색 모달 기능 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -314,6 +314,237 @@ body::before {
 }
 
 /* ========================================
+   Search Modal Styles
+   ======================================== */
+
+@layer components {
+  .search-modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9998;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 15vh;
+    background-color: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
+    animation: lightbox-fade-in 0.15s ease-out;
+  }
+
+  .dark .search-modal-overlay {
+    background-color: rgba(0, 0, 0, 0.7);
+  }
+
+  .search-modal-content {
+    width: 100%;
+    max-width: 36rem;
+    margin: 0 1rem;
+    overflow: hidden;
+    background-color: #fff;
+    border: 1px solid #e4e4e7;
+    border-radius: 0.75rem;
+    box-shadow:
+      0 25px 50px -12px rgb(0 0 0 / 0.25),
+      0 0 0 1px rgb(0 0 0 / 0.03);
+    animation: lightbox-scale-in 0.15s ease-out;
+  }
+
+  .dark .search-modal-content {
+    background-color: #18181b;
+    border-color: #3f3f46;
+    box-shadow:
+      0 25px 50px -12px rgb(0 0 0 / 0.5),
+      0 0 0 1px rgb(255 255 255 / 0.05);
+  }
+
+  .search-modal-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #e4e4e7;
+  }
+
+  .dark .search-modal-input-wrapper {
+    border-bottom-color: #3f3f46;
+  }
+
+  .search-modal-input-icon {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #a1a1aa;
+  }
+
+  .search-modal-input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    font-size: 0.9375rem;
+    color: #18181b;
+    outline: none;
+  }
+
+  .search-modal-input::placeholder {
+    color: #a1a1aa;
+  }
+
+  .dark .search-modal-input {
+    color: #fafafa;
+  }
+
+  .dark .search-modal-input::placeholder {
+    color: #71717a;
+  }
+
+  .search-modal-kbd {
+    flex-shrink: 0;
+    padding: 0.125rem 0.375rem;
+    font-size: 0.75rem;
+    font-family: inherit;
+    color: #a1a1aa;
+    background-color: #f4f4f5;
+    border: 1px solid #e4e4e7;
+    border-radius: 0.25rem;
+  }
+
+  .dark .search-modal-kbd {
+    color: #71717a;
+    background-color: #27272a;
+    border-color: #3f3f46;
+  }
+
+  .search-modal-results {
+    max-height: 20rem;
+    overflow-y: auto;
+    padding: 0.5rem;
+    margin: 0;
+    list-style: none;
+  }
+
+  .search-modal-result-item {
+    border-radius: 0.5rem;
+    transition: background-color 0.1s ease;
+  }
+
+  .search-modal-result-item.active,
+  .search-modal-result-item:hover {
+    background-color: #f4f4f5;
+  }
+
+  .dark .search-modal-result-item.active,
+  .dark .search-modal-result-item:hover {
+    background-color: #27272a;
+  }
+
+  .search-modal-result-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.625rem 0.75rem;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .search-modal-result-title {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: #18181b;
+  }
+
+  .dark .search-modal-result-title {
+    color: #fafafa;
+  }
+
+  .search-modal-result-description {
+    font-size: 0.8125rem;
+    color: #71717a;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .dark .search-modal-result-description {
+    color: #a1a1aa;
+  }
+
+  .search-modal-result-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-top: 0.125rem;
+  }
+
+  .search-modal-result-category {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #b45309;
+    background-color: rgba(251, 191, 36, 0.15);
+    padding: 0.0625rem 0.375rem;
+    border-radius: 9999px;
+  }
+
+  .dark .search-modal-result-category {
+    color: #fbbf24;
+    background-color: rgba(251, 191, 36, 0.1);
+  }
+
+  .search-modal-result-tag {
+    font-size: 0.6875rem;
+    color: #a1a1aa;
+  }
+
+  .search-modal-result-tag::before {
+    content: "#";
+  }
+
+  .dark .search-modal-result-tag {
+    color: #71717a;
+  }
+
+  .search-modal-empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: #71717a;
+    font-size: 0.875rem;
+  }
+
+  .dark .search-modal-empty {
+    color: #a1a1aa;
+  }
+
+  .search-modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    border-top: 1px solid #e4e4e7;
+    font-size: 0.75rem;
+    color: #a1a1aa;
+  }
+
+  .dark .search-modal-footer {
+    border-top-color: #3f3f46;
+    color: #71717a;
+  }
+
+  .search-modal-footer kbd {
+    padding: 0.0625rem 0.25rem;
+    font-size: 0.6875rem;
+    font-family: inherit;
+    background-color: #f4f4f5;
+    border: 1px solid #e4e4e7;
+    border-radius: 0.25rem;
+  }
+
+  .dark .search-modal-footer kbd {
+    background-color: #27272a;
+    border-color: #3f3f46;
+  }
+}
+
+/* ========================================
    Image Lightbox Styles
    ======================================== */
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,9 @@ import { Geist, Geist_Mono, Sacramento } from "next/font/google";
 import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
 import ImageLightbox from "@/components/ImageLightbox";
+import SearchModal from "@/components/SearchModal";
+import SearchButton from "@/components/SearchButton";
+import { postService } from "@/lib/container";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -34,6 +37,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const allPosts = postService.getAllPosts();
+
   return (
     <html lang="ko">
       <body
@@ -69,6 +74,7 @@ export default function RootLayout({
               >
                 About
               </Link>
+              <SearchButton />
               <ThemeToggle />
             </div>
           </nav>
@@ -77,6 +83,7 @@ export default function RootLayout({
         <main className="flex-1">{children}</main>
 
         <ImageLightbox />
+        <SearchModal posts={allPosts} />
 
         <footer className="border-t border-zinc-200 py-8 dark:border-zinc-800">
           <div className="mx-auto max-w-4xl px-4 text-center text-sm text-zinc-500">

--- a/src/components/SearchButton.tsx
+++ b/src/components/SearchButton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useCallback } from "react";
+
+/**
+ * 헤더 검색 버튼.
+ * 클릭 시 커스텀 이벤트를 발생시켜 SearchModal을 연다.
+ */
+export default function SearchButton() {
+  const handleClick = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("open-search-modal"));
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="포스트 검색 (Cmd+K)"
+      className="rounded-md p-1.5 text-amber-700 hover:bg-zinc-100 hover:text-amber-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+    >
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/SearchModal.tsx
+++ b/src/components/SearchModal.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { PostMeta } from "@/types";
+import { useSearch } from "@/hooks/useSearch";
+import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
+import { highlightText } from "@/utils/search";
+
+interface SearchModalProps {
+  posts: PostMeta[];
+}
+
+export default function SearchModal({ posts }: SearchModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  const { query, setQuery, results, isSearching, clearSearch } = useSearch(
+    posts,
+    { debounceMs: 300, minQueryLength: 2 }
+  );
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    setSelectedIndex(-1);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    clearSearch();
+    setSelectedIndex(-1);
+  }, [clearSearch]);
+
+  // Cmd+K / Ctrl+K 단축키로 열기
+  useKeyboardShortcut("k", open);
+
+  // 외부에서 커스텀 이벤트로 열기 (헤더 검색 버튼 등)
+  useEffect(() => {
+    function handleOpenSearch() {
+      open();
+    }
+    window.addEventListener("open-search-modal", handleOpenSearch);
+    return () =>
+      window.removeEventListener("open-search-modal", handleOpenSearch);
+  }, [open]);
+
+  // 모달 열릴 때 input에 포커스
+  useEffect(() => {
+    if (isOpen) {
+      // requestAnimationFrame으로 렌더 후 포커스
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        close();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, close]);
+
+  // 결과 변경 시 선택 인덱스 초기화
+  useEffect(() => {
+    setSelectedIndex(-1);
+  }, [results]);
+
+  // 오버레이 클릭 핸들러
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      // 클릭 대상이 dialog (오버레이) 자체일 때만 닫기
+      if (e.target === e.currentTarget) {
+        close();
+      }
+    },
+    [close]
+  );
+
+  // 키보드 네비게이션
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (results.length === 0) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          prev < results.length - 1 ? prev + 1 : prev
+        );
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+      } else if (e.key === "Enter" && selectedIndex >= 0) {
+        e.preventDefault();
+        const selected = results[selectedIndex];
+        if (selected) {
+          router.push(`/blog/${selected.post.slug}`);
+          close();
+        }
+      }
+    },
+    [results, selectedIndex, router, close]
+  );
+
+  // 검색어 변경 핸들러
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setQuery(e.target.value);
+    },
+    [setQuery]
+  );
+
+  // 결과 항목 클릭 시 모달 닫기
+  const handleResultClick = useCallback(() => {
+    close();
+  }, [close]);
+
+  if (!isOpen) return null;
+
+  const hasQuery = query.trim().length >= 2;
+  const noResults = hasQuery && !isSearching && results.length === 0;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="포스트 검색"
+      className="search-modal-overlay"
+      onClick={handleOverlayClick}
+    >
+      <div
+        className="search-modal-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 검색 입력 */}
+        <div className="search-modal-input-wrapper">
+          <svg
+            className="search-modal-input-icon"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            type="search"
+            role="searchbox"
+            aria-label="포스트 검색"
+            aria-autocomplete="list"
+            aria-controls={results.length > 0 ? "search-results" : undefined}
+            aria-activedescendant={
+              selectedIndex >= 0
+                ? `search-result-${selectedIndex}`
+                : undefined
+            }
+            placeholder="포스트 검색..."
+            value={query}
+            onChange={handleInputChange}
+            onKeyDown={handleKeyDown}
+            className="search-modal-input"
+          />
+          <kbd className="search-modal-kbd">ESC</kbd>
+        </div>
+
+        {/* 검색 결과 */}
+        {results.length > 0 && (
+          <ul
+            id="search-results"
+            role="listbox"
+            aria-label="검색 결과"
+            className="search-modal-results"
+          >
+            {results.map((result, index) => (
+              <li
+                key={result.post.slug}
+                id={`search-result-${index}`}
+                role="option"
+                aria-selected={index === selectedIndex}
+                className={`search-modal-result-item ${
+                  index === selectedIndex ? "active" : ""
+                }`}
+              >
+                <Link
+                  href={`/blog/${result.post.slug}`}
+                  onClick={handleResultClick}
+                  className="search-modal-result-link"
+                >
+                  <span
+                    className="search-modal-result-title"
+                    dangerouslySetInnerHTML={{
+                      __html: highlightText(result.post.title, query),
+                    }}
+                  />
+                  <span className="search-modal-result-description">
+                    {result.post.description}
+                  </span>
+                  <span className="search-modal-result-meta">
+                    <span className="search-modal-result-category">
+                      {result.post.category}
+                    </span>
+                    {result.post.tags.slice(0, 3).map((tag) => (
+                      <span key={tag} className="search-modal-result-tag">
+                        {tag}
+                      </span>
+                    ))}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* 결과 없음 */}
+        {noResults && (
+          <div className="search-modal-empty">
+            <p>검색 결과가 없습니다</p>
+          </div>
+        )}
+
+        {/* 하단 안내 */}
+        <div className="search-modal-footer">
+          <span>
+            <kbd>↑↓</kbd> 탐색
+          </span>
+          <span>
+            <kbd>↵</kbd> 이동
+          </span>
+          <span>
+            <kbd>esc</kbd> 닫기
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/SearchModal.test.tsx
+++ b/src/components/__tests__/SearchModal.test.tsx
@@ -1,0 +1,446 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SearchModal from "../SearchModal";
+import type { PostMeta } from "@/types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+/** useKeyboardShortcut mock: 콜백을 캡처하여 테스트에서 직접 호출 */
+let capturedShortcutCallback: (() => void) | null = null;
+jest.mock("../../hooks/useKeyboardShortcut", () => ({
+  useKeyboardShortcut: (_key: string, callback: () => void) => {
+    capturedShortcutCallback = callback;
+  },
+}));
+
+/** next/link mock */
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+/** next/navigation mock */
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+function createPostMeta(overrides: Partial<PostMeta> = {}): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-01",
+    description: "Test description",
+    category: "Dev",
+    tags: ["test"],
+    readingTime: "5 min read",
+    ...overrides,
+  };
+}
+
+const samplePosts: PostMeta[] = [
+  createPostMeta({
+    slug: "javascript-closure",
+    title: "JavaScript Closure",
+    description: "Understanding closures in JavaScript",
+    category: "JavaScript",
+    tags: ["javascript", "closure"],
+  }),
+  createPostMeta({
+    slug: "react-hooks",
+    title: "React Hooks Guide",
+    description: "Complete guide to React hooks",
+    category: "React",
+    tags: ["react", "hooks"],
+  }),
+  createPostMeta({
+    slug: "nextjs-routing",
+    title: "Next.js Routing",
+    description: "App router patterns in Next.js",
+    category: "Next.js",
+    tags: ["nextjs", "routing"],
+  }),
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** 모달을 여는 헬퍼: useKeyboardShortcut에 캡처된 콜백 호출 */
+function openModal() {
+  act(() => {
+    capturedShortcutCallback?.();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SearchModal", () => {
+  beforeEach(() => {
+    capturedShortcutCallback = null;
+    mockPush.mockClear();
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 1. 초기 상태
+  // ─────────────────────────────────────────────────────
+  describe("초기 상태", () => {
+    test("초기 렌더 시 모달이 보이지 않는다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 모달 열기
+  // ─────────────────────────────────────────────────────
+  describe("모달 열기", () => {
+    test("키보드 단축키로 모달이 열린다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("모달 열림 시 검색 입력 필드가 존재한다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      expect(searchInput).toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. 검색 동작
+  // ─────────────────────────────────────────────────────
+  describe("검색 동작", () => {
+    test("검색어 입력 시 일치하는 결과가 표시된다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: "closure" } });
+      });
+
+      // useSearch 디바운스 대기 (300ms)
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // highlightText가 mark 태그로 감싸므로 link로 검색
+      expect(
+        screen.getByRole("link", { name: /JavaScript Closure/i })
+      ).toBeInTheDocument();
+
+      jest.useRealTimers();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 4. 결과 표시
+  // ─────────────────────────────────────────────────────
+  describe("결과 표시", () => {
+    test("검색 결과에 제목, 설명, 카테고리가 표시된다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: "closure" } });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // 제목 (link 내부, highlightText로 mark 태그 포함 가능)
+      expect(
+        screen.getByRole("link", { name: /JavaScript Closure/i })
+      ).toBeInTheDocument();
+      // 설명
+      expect(
+        screen.getByText("Understanding closures in JavaScript")
+      ).toBeInTheDocument();
+      // 카테고리 (search-modal-result-category 클래스 내)
+      const categoryEl = document.querySelector(
+        ".search-modal-result-category"
+      );
+      expect(categoryEl).toBeInTheDocument();
+      expect(categoryEl).toHaveTextContent("JavaScript");
+
+      jest.useRealTimers();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 5. 포스트 이동
+  // ─────────────────────────────────────────────────────
+  describe("포스트 이동", () => {
+    test("검색 결과 클릭 시 올바른 URL 링크가 존재한다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: "closure" } });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      const link = screen.getByRole("link", { name: /JavaScript Closure/i });
+      expect(link).toHaveAttribute("href", "/blog/javascript-closure");
+
+      jest.useRealTimers();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 6. ESC로 닫기
+  // ─────────────────────────────────────────────────────
+  describe("ESC로 닫기", () => {
+    test("ESC 키를 누르면 모달이 닫힌다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      act(() => {
+        fireEvent.keyDown(document, { key: "Escape" });
+      });
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 7. 오버레이 클릭으로 닫기
+  // ─────────────────────────────────────────────────────
+  describe("오버레이 클릭으로 닫기", () => {
+    test("배경 오버레이 클릭 시 모달이 닫힌다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const dialog = screen.getByRole("dialog");
+
+      act(() => {
+        fireEvent.click(dialog);
+      });
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    test("모달 콘텐츠 영역 클릭은 닫기를 트리거하지 않는다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+
+      act(() => {
+        fireEvent.click(searchInput);
+      });
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 8. 결과 없음
+  // ─────────────────────────────────────────────────────
+  describe("결과 없음", () => {
+    test("검색 결과가 없을 때 안내 메시지가 표시된다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, {
+          target: { value: "zzzznotexist" },
+        });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(screen.getByText(/검색 결과가 없습니다/)).toBeInTheDocument();
+
+      jest.useRealTimers();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 9. 키보드 네비게이션
+  // ─────────────────────────────────────────────────────
+  describe("키보드 네비게이션", () => {
+    test("ArrowDown 키로 검색 결과 항목을 탐색할 수 있다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        // "React"와 "Next.js" 모두 매칭되는 넓은 검색어
+        fireEvent.change(searchInput, { target: { value: "guide" } });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // ArrowDown으로 첫 번째 결과 항목 선택
+      act(() => {
+        fireEvent.keyDown(searchInput, { key: "ArrowDown" });
+      });
+
+      const resultItems = screen.getAllByRole("option");
+      expect(resultItems[0]).toHaveAttribute("aria-selected", "true");
+
+      jest.useRealTimers();
+    });
+
+    test("ArrowUp 키로 이전 결과 항목으로 이동할 수 있다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: "guide" } });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // ArrowDown 두 번 누른 후
+      act(() => {
+        fireEvent.keyDown(searchInput, { key: "ArrowDown" });
+      });
+      act(() => {
+        fireEvent.keyDown(searchInput, { key: "ArrowDown" });
+      });
+
+      // ArrowUp으로 이전 항목으로
+      act(() => {
+        fireEvent.keyDown(searchInput, { key: "ArrowUp" });
+      });
+
+      const resultItems = screen.getAllByRole("option");
+      expect(resultItems[0]).toHaveAttribute("aria-selected", "true");
+
+      jest.useRealTimers();
+    });
+
+    test("Enter 키로 선택된 결과 항목의 페이지로 이동한다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: "React Hooks" } });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // ArrowDown으로 첫 번째 항목 선택 후 Enter
+      act(() => {
+        fireEvent.keyDown(searchInput, { key: "ArrowDown" });
+      });
+      act(() => {
+        fireEvent.keyDown(searchInput, { key: "Enter" });
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/blog/react-hooks");
+
+      jest.useRealTimers();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 10. 접근성
+  // ─────────────────────────────────────────────────────
+  describe("접근성", () => {
+    test("모달에 role=dialog와 aria-modal=true가 설정된다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    test("검색 입력 필드에 적절한 aria-label이 있다", () => {
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      expect(searchInput).toHaveAttribute("aria-label");
+    });
+
+    test("검색 결과 목록에 role=listbox가 설정된다", async () => {
+      jest.useFakeTimers();
+      render(<SearchModal posts={samplePosts} />);
+
+      openModal();
+
+      const searchInput = screen.getByRole("searchbox");
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: "JavaScript" } });
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+      jest.useRealTimers();
+    });
+  });
+});

--- a/src/hooks/__tests__/useKeyboardShortcut.test.ts
+++ b/src/hooks/__tests__/useKeyboardShortcut.test.ts
@@ -1,0 +1,203 @@
+import { renderHook, act } from "@testing-library/react";
+import { useKeyboardShortcut } from "../useKeyboardShortcut";
+
+describe("useKeyboardShortcut", () => {
+  // ─────────────────────────────────────────────────────
+  // 1. 기본 단축키 감지
+  // ─────────────────────────────────────────────────────
+  describe("단축키 감지", () => {
+    test("Cmd+K (Mac) 누르면 콜백이 호출된다", () => {
+      const callback = jest.fn();
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test("Ctrl+K (Windows/Linux) 누르면 콜백이 호출된다", () => {
+      const callback = jest.fn();
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            ctrlKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    test("modifier 없이 K키만 누르면 콜백이 호출되지 않는다", () => {
+      const callback = jest.fn();
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. input/textarea 포커스 시 무시
+  // ─────────────────────────────────────────────────────
+  describe("입력 필드 포커스 시 무시", () => {
+    test("input에 포커스가 있으면 단축키가 무시된다", () => {
+      const callback = jest.fn();
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+      input.focus();
+
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+      document.body.removeChild(input);
+    });
+
+    test("textarea에 포커스가 있으면 단축키가 무시된다", () => {
+      const callback = jest.fn();
+      const textarea = document.createElement("textarea");
+      document.body.appendChild(textarea);
+      textarea.focus();
+
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+      document.body.removeChild(textarea);
+    });
+
+    test("contentEditable 요소에 포커스가 있으면 단축키가 무시된다", () => {
+      const callback = jest.fn();
+      const div = document.createElement("div");
+      div.setAttribute("contenteditable", "true");
+      document.body.appendChild(div);
+      div.focus();
+
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+      document.body.removeChild(div);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. 브라우저 기본 동작 차단
+  // ─────────────────────────────────────────────────────
+  describe("기본 동작 차단", () => {
+    test("단축키 감지 시 preventDefault가 호출된다", () => {
+      const callback = jest.fn();
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      const event = new KeyboardEvent("keydown", {
+        key: "k",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const preventDefaultSpy = jest.spyOn(event, "preventDefault");
+
+      act(() => {
+        document.dispatchEvent(event);
+      });
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 4. 언마운트 시 정리
+  // ─────────────────────────────────────────────────────
+  describe("클린업", () => {
+    test("언마운트 후 이벤트 리스너가 제거된다", () => {
+      const callback = jest.fn();
+      const { unmount } = renderHook(() =>
+        useKeyboardShortcut("k", callback)
+      );
+
+      unmount();
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "k",
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 5. 대소문자 무시
+  // ─────────────────────────────────────────────────────
+  describe("대소문자 무시", () => {
+    test("대문자 K를 눌러도 콜백이 호출된다", () => {
+      const callback = jest.fn();
+      renderHook(() => useKeyboardShortcut("k", callback));
+
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "K",
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/useKeyboardShortcut.ts
+++ b/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * 키보드 단축키를 감지하는 커스텀 훅.
+ *
+ * - Cmd(Mac) 또는 Ctrl(Win/Linux) + 지정 키 조합을 감지
+ * - input, textarea, contentEditable 요소에 포커스 중이면 무시
+ * - 브라우저 기본 동작 차단 (preventDefault)
+ *
+ * @param key 감지할 키 (소문자)
+ * @param callback 단축키 감지 시 호출할 콜백
+ */
+export function useKeyboardShortcut(
+  key: string,
+  callback: () => void
+): void {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      // modifier 키 확인 (Cmd 또는 Ctrl)
+      if (!event.metaKey && !event.ctrlKey) return;
+
+      // 대소문자 무시 비교
+      if (event.key.toLowerCase() !== key.toLowerCase()) return;
+
+      // 입력 필드에 포커스 중이면 무시
+      const activeElement = document.activeElement;
+      if (activeElement) {
+        const tagName = activeElement.tagName.toLowerCase();
+        if (tagName === "input" || tagName === "textarea") return;
+        if (activeElement.getAttribute("contenteditable") === "true") return;
+      }
+
+      event.preventDefault();
+      callbackRef.current();
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [key]);
+}


### PR DESCRIPTION
## Summary
- Cmd+K / Ctrl+K 단축키 및 헤더 검색 버튼으로 포스트 검색 모달 오픈 기능 추가
- 제목/설명/태그 기반 검색, 디바운스(300ms), 하이라이트 표시
- 키보드 네비게이션(↑↓ 탐색, Enter 이동, ESC 닫기), 다크/라이트 모드 지원

Closes #47

## 변경 파일
- `src/hooks/useKeyboardShortcut.ts` - Cmd+K/Ctrl+K 단축키 감지 훅
- `src/components/SearchModal.tsx` - 검색 모달 컴포넌트 (오버레이, 입력, 결과목록, 키보드 네비게이션)
- `src/components/SearchButton.tsx` - 헤더 검색 버튼 (돋보기 아이콘)
- `src/app/layout.tsx` - 글로벌 레이아웃에 SearchModal, SearchButton 통합
- `src/app/globals.css` - 검색 모달 CSS 스타일 (다크모드 포함)

## Test plan
- [x] useKeyboardShortcut 훅 테스트 9개 통과
- [x] SearchModal 컴포넌트 테스트 16개 통과
- [x] 전체 테스트 196개 통과 (15 suites)
- [x] Next.js 빌드 성공
- [x] 보안 리뷰 통과 (CRITICAL/HIGH 이슈 0건)
- [x] 데스크톱/모바일 수동 테스트
- [x] 라이트/다크 모드 수동 테스트