### PR TITLE
feat: 목차(TOC) 접기/펼치기 토글 기능 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -247,11 +247,14 @@ body::before {
   border: none;
   cursor: pointer;
   padding: 0;
-  outline: none;
 }
 
 .toc-toggle-button:hover {
   opacity: 0.8;
+}
+
+.toc-toggle-button:focus:not(:focus-visible) {
+  outline: none;
 }
 
 .toc-toggle-button:focus-visible {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -241,6 +241,49 @@ body::before {
   border: 1px solid #fde68a;
 }
 
+/* TOC Toggle Button */
+.toc-toggle-button {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  outline: none;
+}
+
+.toc-toggle-button:hover {
+  opacity: 0.8;
+}
+
+.toc-toggle-button:focus-visible {
+  outline: 2px solid #fbbf24;
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+.dark .toc-toggle-button:focus-visible {
+  outline-color: #60a5fa;
+}
+
+.toc-toggle-icon {
+  flex-shrink: 0;
+}
+
+/* TOC List Toggle */
+.toc-list {
+  overflow: hidden;
+}
+
+.toc-list-open {
+  max-height: 1000px;
+  opacity: 1;
+}
+
+.toc-list-closed {
+  max-height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* Heading highlight animation */
 @keyframes heading-flash {
   0% {

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -19,16 +19,24 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
   // localStorage에서 초기 상태 로드 (hydration mismatch 방지)
   useEffect(() => {
     setMounted(true);
-    const stored = localStorage.getItem(TOC_STORAGE_KEY);
-    if (stored !== null) {
-      setIsOpen(stored === "true");
+    try {
+      const stored = localStorage.getItem(TOC_STORAGE_KEY);
+      if (stored !== null) {
+        setIsOpen(stored === "true");
+      }
+    } catch {
+      // localStorage 접근 불가 시 기본값(true) 유지
     }
   }, []);
 
   // 토글 상태 변경 시 localStorage 저장
   useEffect(() => {
     if (mounted) {
-      localStorage.setItem(TOC_STORAGE_KEY, String(isOpen));
+      try {
+        localStorage.setItem(TOC_STORAGE_KEY, String(isOpen));
+      } catch {
+        // 저장 실패 시 무시
+      }
     }
   }, [isOpen, mounted]);
 


### PR DESCRIPTION
## Summary
- 목차(TOC) 헤더를 클릭하여 접기/펼치기 토글 기능 추가 (#54)
- chevron 아이콘 회전 애니메이션으로 상태 시각적 표현
- localStorage로 토글 상태 유지 (페이지 이동 시 보존)
- aria-expanded 속성 및 키보드 조작으로 접근성 지원
- CSS transition으로 부드러운 슬라이드 애니메이션

## 변경 파일
- `src/components/TableOfContents.tsx` - 토글 상태, 버튼, chevron 아이콘, localStorage 연동
- `src/app/globals.css` - 토글 버튼 스타일, 리스트 접기/펼치기 CSS

## Test plan
- [x] 목차 토글 버튼 클릭 시 접기/펼치기 동작 확인
- [x] 페이지 새로고침 후 토글 상태 유지 확인 (localStorage)
- [x] 다른 블로그 글로 이동 후 토글 상태 유지 확인
- [x] 키보드(Tab → Enter/Space) 토글 동작 확인
- [x] 다크모드에서 토글 버튼 스타일 확인
- [x] 접힌 상태에서 목차 링크 클릭 불가 확인 (pointer-events: none)

Closes #54