### PR TITLE
feat: 블로그 글 내 용어 설명(글로서리) 기능 추가 (#53)

### DIFF
--- a/content/posts/javascript-closure.md
+++ b/content/posts/javascript-closure.md
@@ -5,6 +5,23 @@ description: "JavaScript 클로저의 동작 원리부터 실무 활용 패턴�
 category: "개발"
 subcategory: "JavaScript"
 tags: ["guide", "intermediate"]
+glossary:
+  - id: "closure"
+    term: "클로저(Closure)"
+    brief: "함수가 선언된 렉시컬 환경을 기억하여 외부 스코프 변수에 접근할 수 있는 현상"
+    detail: "함수가 자신이 선언된 환경의 변수를 기억하고, 외부 함수 실행이 종료된 후에도 해당 변수에 접근할 수 있는 JavaScript의 핵심 메커니즘이다. 함수와 그 함수가 선언된 렉시컬 환경의 조합으로 정의된다."
+  - id: "lexical-scope"
+    term: "렉시컬 스코프(Lexical Scope)"
+    brief: "함수가 호출 위치가 아닌 선언 위치에 따라 스코프가 결정되는 규칙"
+    detail: "정적 스코프(Static Scope)라고도 한다. 함수가 어디서 호출되었는지가 아니라 어디서 작성(선언)되었는지에 따라 접근 가능한 변수의 범위가 결정된다."
+  - id: "iife"
+    term: "즉시 실행 함수(IIFE)"
+    brief: "선언과 동시에 실행되는 함수 표현식"
+    detail: "Immediately Invoked Function Expression의 약자. (function() { ... })() 형태로 작성하며, 함수를 정의하자마자 즉시 실행한다. 독립적인 스코프를 생성하여 변수 오염을 방지하는 데 사용된다."
+  - id: "garbage-collection"
+    term: "가비지 컬렉션(Garbage Collection)"
+    brief: "더 이상 참조되지 않는 메모리를 자동으로 해제하는 메커니즘"
+    detail: "JavaScript 엔진이 더 이상 사용되지 않는 객체나 변수의 메모리를 자동으로 회수하는 메모리 관리 메커니즘이다. 클로저가 외부 변수를 참조하면 해당 변수는 가비지 컬렉션 대상에서 제외된다."
 ---
 
 <figure>
@@ -21,17 +38,7 @@ tags: ["guide", "intermediate"]
 JavaScript를 사용하다 보면 "클로저"라는 단어를 자주 접하게 됩니다.
 면접 단골 주제이기도 하고, 실무에서도 의식하지 못한 채 사용하고 있는 경우가 많습니다.
 
-클로저(Closure)는 **함수가 자신이 선언된 렉시컬 환경을 기억하여, 외부 스코프의 변수에 접근할 수 있는 현상**입니다.
-
-<details>
-<summary>용어 설명: 렉시컬 스코프와 외부 스코프</summary>
-
-<strong>렉시컬 스코프(Lexical Scope)</strong>란, 함수가 어디서 <strong>호출</strong>되었는지가 아니라 어디서 <strong>작성(선언)</strong>되었는지에 따라 접근할 수 있는 변수의 범위가 결정되는 규칙을 말합니다.
-
-<strong>외부 스코프</strong>는 함수 자신을 감싸고 있는 바깥쪽 함수(또는 전역)의 변수 영역을 의미합니다.
-즉 함수 안에 또 다른 함수가 있을 때, 안쪽 함수 입장에서 바깥쪽 함수의 변수 영역이 외부 스코프입니다.
-
-</details>
+<Term id="closure">클로저(Closure)</Term>는 **함수가 자신이 선언된 <Term id="lexical-scope">렉시컬 환경</Term>을 기억하여, 외부 스코프의 변수에 접근할 수 있는 현상**입니다.
 
 비유하자면, 회사를 퇴사한 직원이 재직 시절 사용하던 사물함 비밀번호를 여전히 기억하고 있는 것과 비슷합니다.
 회사(외부 함수)와의 관계는 끝났지만, 그 안에서 알게 된 정보(변수)에는 여전히 접근할 수 있는 셈입니다.
@@ -61,7 +68,7 @@ closureFunc();  // 'Hello' - message가 여전히 접근 가능
 ```
 
 `outer()` 함수는 이미 실행이 끝났지만, 반환된 `inner` 함수는 여전히 `message` 변수에 접근할 수 있습니다.
-일반적이라면 함수 종료와 함께 지역 변수도 사라져야 하지만, `inner`가 `message`를 참조하고 있기 때문에 가비지 컬렉션 대상에서 제외됩니다.
+일반적이라면 함수 종료와 함께 지역 변수도 사라져야 하지만, `inner`가 `message`를 참조하고 있기 때문에 <Term id="garbage-collection">가비지 컬렉션</Term> 대상에서 제외됩니다.
 이것이 클로저의 핵심입니다.
 
 ## 클로저의 동작 원리
@@ -293,13 +300,13 @@ for (var i = 0; i < 3; i++) {
 }
 ```
 
-즉시 실행 함수(IIFE)가 각 반복의 `i` 값을 `capturedI`로 캡처합니다.
+<Term id="iife">즉시 실행 함수(IIFE)</Term>가 각 반복의 `i` 값을 `capturedI`로 캡처합니다.
 `let`이 없던 ES5 시절에 주로 사용하던 방식입니다.
 
 ## 모듈 패턴
 
 클로저의 가장 실용적인 활용 중 하나가 모듈 패턴입니다.
-IIFE와 클로저를 결합하여 private 영역과 public API를 분리합니다.
+<Term id="iife">IIFE</Term>와 클로저를 결합하여 private 영역과 public API를 분리합니다.
 
 ```javascript
 const Calculator = (function () {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";
 import TableOfContents from "@/components/TableOfContents";
 import RelatedPosts from "@/components/RelatedPosts";
+import { GlossaryProvider, GlossarySection, Term } from "@/components/glossary";
 import type { Metadata } from "next";
 
 interface Props {
@@ -42,6 +43,20 @@ export default async function BlogPostPage({ params }: Props) {
 
   const headings = extractHeadings(post.content);
   const relatedPosts = postService.getRelatedPosts(slug, 3);
+  const glossary = post.glossary ?? [];
+
+  const mdxContent = (
+    <MDXRemote
+      source={post.content}
+      components={{ Term }}
+      options={{
+        mdxOptions: {
+          remarkPlugins: [remarkGfm],
+          rehypePlugins: [rehypeSlug],
+        },
+      }}
+    />
+  );
 
   return (
     <div className="relative mx-auto max-w-6xl px-4 py-16">
@@ -75,17 +90,18 @@ export default async function BlogPostPage({ params }: Props) {
             <div className="mt-4 text-sm text-zinc-500">{post.readingTime}</div>
           </header>
 
-          <div className="prose prose-zinc max-w-none dark:prose-invert prose-headings:font-semibold prose-a:text-amber-700 hover:prose-a:text-amber-800 prose-code:rounded prose-code:bg-amber-100 prose-code:px-1 prose-code:py-0.5 prose-code:text-amber-900 prose-code:before:content-none prose-code:after:content-none dark:prose-a:text-blue-400 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200">
-            <MDXRemote
-              source={post.content}
-              options={{
-                mdxOptions: {
-                  remarkPlugins: [remarkGfm],
-                  rehypePlugins: [rehypeSlug],
-                },
-              }}
-            />
-          </div>
+          {glossary.length > 0 ? (
+            <GlossaryProvider entries={glossary}>
+              <div className="prose prose-zinc max-w-none dark:prose-invert prose-headings:font-semibold prose-a:text-amber-700 hover:prose-a:text-amber-800 prose-code:rounded prose-code:bg-amber-100 prose-code:px-1 prose-code:py-0.5 prose-code:text-amber-900 prose-code:before:content-none prose-code:after:content-none dark:prose-a:text-blue-400 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200">
+                {mdxContent}
+              </div>
+              <GlossarySection entries={glossary} />
+            </GlossaryProvider>
+          ) : (
+            <div className="prose prose-zinc max-w-none dark:prose-invert prose-headings:font-semibold prose-a:text-amber-700 hover:prose-a:text-amber-800 prose-code:rounded prose-code:bg-amber-100 prose-code:px-1 prose-code:py-0.5 prose-code:text-amber-900 prose-code:before:content-none prose-code:after:content-none dark:prose-a:text-blue-400 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200">
+              {mdxContent}
+            </div>
+          )}
 
           <RelatedPosts posts={relatedPosts} />
         </article>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -90,18 +90,12 @@ export default async function BlogPostPage({ params }: Props) {
             <div className="mt-4 text-sm text-zinc-500">{post.readingTime}</div>
           </header>
 
-          {glossary.length > 0 ? (
-            <GlossaryProvider entries={glossary}>
-              <div className="prose prose-zinc max-w-none dark:prose-invert prose-headings:font-semibold prose-a:text-amber-700 hover:prose-a:text-amber-800 prose-code:rounded prose-code:bg-amber-100 prose-code:px-1 prose-code:py-0.5 prose-code:text-amber-900 prose-code:before:content-none prose-code:after:content-none dark:prose-a:text-blue-400 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200">
-                {mdxContent}
-              </div>
-              <GlossarySection entries={glossary} />
-            </GlossaryProvider>
-          ) : (
+          <GlossaryProvider entries={glossary}>
             <div className="prose prose-zinc max-w-none dark:prose-invert prose-headings:font-semibold prose-a:text-amber-700 hover:prose-a:text-amber-800 prose-code:rounded prose-code:bg-amber-100 prose-code:px-1 prose-code:py-0.5 prose-code:text-amber-900 prose-code:before:content-none prose-code:after:content-none dark:prose-a:text-blue-400 dark:prose-code:bg-zinc-800 dark:prose-code:text-zinc-200">
               {mdxContent}
             </div>
-          )}
+            {glossary.length > 0 && <GlossarySection entries={glossary} />}
+          </GlossaryProvider>
 
           <RelatedPosts posts={relatedPosts} />
         </article>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -137,6 +137,193 @@ body::before {
   animation-delay: 0.3s;
 }
 
+/* ========================================
+   Glossary Term Styles
+   ======================================== */
+
+@layer prose-overrides {
+  /* 본문 내 용어 강조 스타일 */
+  .glossary-term {
+    position: relative;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-decoration-color: #b45309;
+    text-underline-offset: 3px;
+    cursor: pointer;
+    font-style: normal;
+    color: #92400e;
+    transition: all 0.2s ease;
+  }
+
+  .glossary-term:hover,
+  .glossary-term:focus {
+    text-decoration-style: solid;
+    background-color: rgba(251, 191, 36, 0.15);
+    border-radius: 0.125rem;
+  }
+
+  .glossary-term:focus-visible {
+    outline: 2px solid #fbbf24;
+    outline-offset: 2px;
+    border-radius: 0.125rem;
+  }
+
+  .dark .glossary-term {
+    text-decoration-color: #60a5fa;
+    color: #93c5fd;
+  }
+
+  .dark .glossary-term:hover,
+  .dark .glossary-term:focus {
+    background-color: rgba(96, 165, 250, 0.15);
+  }
+
+  .dark .glossary-term:focus-visible {
+    outline-color: #60a5fa;
+  }
+
+  /* 툴팁 */
+  .glossary-tooltip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 50;
+    width: max-content;
+    max-width: 280px;
+    padding: 0.5rem 0.75rem;
+    background-color: #1c1917;
+    color: #fafaf9;
+    font-size: 0.8125rem;
+    line-height: 1.5;
+    border-radius: 0.5rem;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 0.2);
+    text-decoration: none;
+    pointer-events: auto;
+    animation: lightbox-fade-in 0.15s ease-out;
+  }
+
+  /* 툴팁 화살표 */
+  .glossary-tooltip::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #1c1917;
+  }
+
+  .dark .glossary-tooltip {
+    background-color: #f5f5f4;
+    color: #1c1917;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 0.4);
+  }
+
+  .dark .glossary-tooltip::after {
+    border-top-color: #f5f5f4;
+  }
+
+  .glossary-tooltip-more {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #a8a29e;
+  }
+
+  .dark .glossary-tooltip-more {
+    color: #78716c;
+  }
+}
+
+/* ========================================
+   Glossary Section Styles (하단 용어 목록)
+   ======================================== */
+
+.glossary-section {
+  margin-top: 3rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  border: 1px solid #fde68a;
+  border-radius: 0.75rem;
+}
+
+.dark .glossary-section {
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+  border-color: #334155;
+}
+
+.glossary-section-title {
+  margin: 0 0 1rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #92400e;
+}
+
+.dark .glossary-section-title {
+  color: #e2e8f0;
+}
+
+.glossary-list {
+  margin: 0;
+}
+
+.glossary-item {
+  padding: 0.75rem 0;
+  border-top: 1px solid rgba(253, 230, 138, 0.5);
+  scroll-margin-top: 6rem;
+}
+
+.glossary-item:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.dark .glossary-item {
+  border-top-color: rgba(51, 65, 85, 0.5);
+}
+
+.glossary-item-term {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-weight: 600;
+  color: #78350f;
+  font-size: 0.9375rem;
+}
+
+.dark .glossary-item-term {
+  color: #fbbf24;
+}
+
+.glossary-back-link {
+  font-size: 0.75rem;
+  color: #b45309;
+  text-decoration: none;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+}
+
+.glossary-back-link:hover {
+  opacity: 1;
+}
+
+.dark .glossary-back-link {
+  color: #60a5fa;
+}
+
+.glossary-item-detail {
+  margin: 0.375rem 0 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: #78350f;
+}
+
+.dark .glossary-item-detail {
+  color: #94a3b8;
+}
+
 /* Code blocks - @layer를 사용하여 typography 플러그인 스타일 오버라이드 */
 @layer prose-overrides {
   /* 라이트모드: 따뜻한 톤 */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,6 +153,7 @@ body::before {
     font-style: normal;
     color: #92400e;
     transition: all 0.2s ease;
+    scroll-margin-top: 6rem;
   }
 
   .glossary-term:hover,
@@ -253,8 +254,20 @@ body::before {
   border-color: #334155;
 }
 
+.glossary-toggle-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+}
+
 .glossary-section-title {
-  margin: 0 0 1rem;
+  margin: 0;
   font-size: 1.125rem;
   font-weight: 600;
   color: #92400e;
@@ -264,8 +277,34 @@ body::before {
   color: #e2e8f0;
 }
 
+.glossary-toggle-icon {
+  width: 1rem;
+  height: 1rem;
+  color: #92400e;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.dark .glossary-toggle-icon {
+  color: #e2e8f0;
+}
+
 .glossary-list {
   margin: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease, margin-top 0.3s ease;
+}
+
+.glossary-list-open {
+  max-height: 2000px;
+  opacity: 1;
+  margin-top: 1rem;
+}
+
+.glossary-list-closed {
+  max-height: 0;
+  opacity: 0;
+  margin-top: 0;
 }
 
 .glossary-item {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -296,7 +296,7 @@ body::before {
 }
 
 .glossary-list-open {
-  max-height: 2000px;
+  max-height: 9999px;
   opacity: 1;
   margin-top: 1rem;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -170,17 +170,17 @@ body::before {
   }
 
   .dark .glossary-term {
-    text-decoration-color: #60a5fa;
-    color: #93c5fd;
+    text-decoration-color: #f59e0b;
+    color: #fbbf24;
   }
 
   .dark .glossary-term:hover,
   .dark .glossary-term:focus {
-    background-color: rgba(96, 165, 250, 0.15);
+    background-color: rgba(251, 191, 36, 0.15);
   }
 
   .dark .glossary-term:focus-visible {
-    outline-color: #60a5fa;
+    outline-color: #f59e0b;
   }
 
   /* 툴팁 */
@@ -337,11 +337,13 @@ body::before {
 }
 
 .glossary-back-link {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   color: #b45309;
   text-decoration: none;
-  opacity: 0.6;
+  opacity: 0.8;
   transition: opacity 0.2s ease;
+  margin-left: 0.375rem;
+  font-weight: 600;
 }
 
 .glossary-back-link:hover {
@@ -349,7 +351,7 @@ body::before {
 }
 
 .dark .glossary-back-link {
-  color: #60a5fa;
+  color: #fbbf24;
 }
 
 .glossary-item-detail {
@@ -576,6 +578,16 @@ body::before {
 }
 
 .dark .heading-highlight {
+  animation: heading-flash-dark 1.5s ease-in-out;
+}
+
+/* Glossary highlight animation */
+.glossary-highlight {
+  animation: heading-flash 1.5s ease-in-out;
+  border-radius: 0.25rem;
+}
+
+.dark .glossary-highlight {
   animation: heading-flash-dark 1.5s ease-in-out;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -581,14 +581,104 @@ body::before {
   animation: heading-flash-dark 1.5s ease-in-out;
 }
 
-/* Glossary highlight animation */
+/* Glossary Term highlight - pulsing ring (용어 설명 → 본문 Term) */
+@keyframes term-pulse-ring {
+  0% {
+    background-color: rgba(59, 130, 246, 0.35);
+    outline: 2px solid rgba(59, 130, 246, 0.8);
+    outline-offset: 0px;
+  }
+  40% {
+    background-color: rgba(59, 130, 246, 0.2);
+    outline: 2px solid rgba(59, 130, 246, 0.4);
+    outline-offset: 6px;
+  }
+  70% {
+    outline: 2px solid rgba(59, 130, 246, 0);
+    outline-offset: 10px;
+  }
+  100% {
+    background-color: transparent;
+    outline: 2px solid transparent;
+    outline-offset: 10px;
+  }
+}
+
+@keyframes term-pulse-ring-dark {
+  0% {
+    background-color: rgba(96, 165, 250, 0.3);
+    outline: 2px solid rgba(96, 165, 250, 0.7);
+    outline-offset: 0px;
+  }
+  40% {
+    background-color: rgba(96, 165, 250, 0.15);
+    outline: 2px solid rgba(96, 165, 250, 0.35);
+    outline-offset: 6px;
+  }
+  70% {
+    outline: 2px solid rgba(96, 165, 250, 0);
+    outline-offset: 10px;
+  }
+  100% {
+    background-color: transparent;
+    outline: 2px solid transparent;
+    outline-offset: 10px;
+  }
+}
+
 .glossary-highlight {
-  animation: heading-flash 1.5s ease-in-out;
+  animation: term-pulse-ring 2s ease-out;
   border-radius: 0.25rem;
 }
 
 .dark .glossary-highlight {
-  animation: heading-flash-dark 1.5s ease-in-out;
+  animation: term-pulse-ring-dark 2s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glossary-highlight {
+    animation: none;
+    background-color: rgba(59, 130, 246, 0.3);
+    outline: 2px solid rgba(59, 130, 246, 0.5);
+    outline-offset: 2px;
+  }
+  .dark .glossary-highlight {
+    animation: none;
+    background-color: rgba(96, 165, 250, 0.25);
+    outline: 2px solid rgba(96, 165, 250, 0.4);
+    outline-offset: 2px;
+  }
+}
+
+/* Glossary entry highlight - background fade (본문 Term → 용어 설명) */
+@keyframes entry-bg-fade {
+  0% { background-color: rgba(59, 130, 246, 0.25); }
+  100% { background-color: transparent; }
+}
+
+@keyframes entry-bg-fade-dark {
+  0% { background-color: rgba(96, 165, 250, 0.2); }
+  100% { background-color: transparent; }
+}
+
+.glossary-entry-highlight {
+  animation: entry-bg-fade 2s ease-out;
+  border-radius: 0.375rem;
+}
+
+.dark .glossary-entry-highlight {
+  animation: entry-bg-fade-dark 2s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glossary-entry-highlight {
+    animation: none;
+    background-color: rgba(59, 130, 246, 0.2);
+  }
+  .dark .glossary-entry-highlight {
+    animation: none;
+    background-color: rgba(96, 165, 250, 0.15);
+  }
 }
 
 /* ========================================

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef } from "react";
 import type { TocItem } from "@/lib/toc";
+import { scrollAndHighlight } from "@/lib/scrollHighlight";
 
 interface TableOfContentsProps {
   headings: TocItem[];
@@ -133,14 +134,8 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
                     clickedRef.current = false;
                   }, 2000);
 
-                  // 스크롤
-                  element.scrollIntoView({ behavior: "smooth" });
-
-                  // 헤딩 강조 애니메이션 추가
-                  element.classList.add("heading-highlight");
-                  setTimeout(() => {
-                    element.classList.remove("heading-highlight");
-                  }, 1500);
+                  // 스크롤 + 헤딩 강조 애니메이션
+                  scrollAndHighlight(element, "heading-highlight");
                 }
               }}
             >

--- a/src/components/__tests__/GlossarySection.test.tsx
+++ b/src/components/__tests__/GlossarySection.test.tsx
@@ -125,4 +125,53 @@ describe("GlossarySection", () => {
     const list = container.querySelector(".glossary-list");
     expect(list).toHaveClass("glossary-list-open");
   });
+
+  it("↑ 클릭 시 smooth scroll로 본문 용어 위치로 이동한다", () => {
+    const mockScrollIntoView = jest.fn();
+    const mockClassList = { add: jest.fn(), remove: jest.fn() };
+    const mockElement = {
+      scrollIntoView: mockScrollIntoView,
+      classList: mockClassList,
+    };
+    jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
+
+    renderWithProvider();
+
+    const backLink = screen.getAllByLabelText("본문으로 돌아가기")[0];
+    fireEvent.click(backLink);
+
+    expect(document.getElementById).toHaveBeenCalledWith("term-closure");
+    expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+
+    jest.restoreAllMocks();
+  });
+
+  it("↑ 클릭 시 스크롤 완료 후 대상 Term에 강조 애니메이션을 적용한다", () => {
+    Object.defineProperty(window, "onscrollend", {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    const mockClassList = { add: jest.fn(), remove: jest.fn() };
+    const mockElement = {
+      scrollIntoView: jest.fn(),
+      classList: mockClassList,
+    };
+    jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
+
+    renderWithProvider();
+
+    const backLink = screen.getAllByLabelText("본문으로 돌아가기")[0];
+    fireEvent.click(backLink);
+
+    expect(mockClassList.add).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event("scrollend"));
+
+    expect(mockClassList.add).toHaveBeenCalledWith("glossary-highlight");
+
+    delete (window as Record<string, unknown>)["onscrollend"];
+    jest.restoreAllMocks();
+  });
 });

--- a/src/components/__tests__/GlossarySection.test.tsx
+++ b/src/components/__tests__/GlossarySection.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { GlossarySection } from "../glossary/GlossarySection";
+import { GlossaryProvider } from "../glossary/GlossaryProvider";
 import type { GlossaryEntry } from "@/types";
 
 const mockEntries: GlossaryEntry[] = [
@@ -17,9 +18,17 @@ const mockEntries: GlossaryEntry[] = [
   },
 ];
 
+function renderWithProvider(entries = mockEntries) {
+  return render(
+    <GlossaryProvider entries={entries}>
+      <GlossarySection entries={entries} />
+    </GlossaryProvider>
+  );
+}
+
 describe("GlossarySection", () => {
   it("용어 목록을 dl/dt/dd 태그로 렌더링한다", () => {
-    const { container } = render(<GlossarySection entries={mockEntries} />);
+    const { container } = renderWithProvider();
 
     const dl = container.querySelector("dl");
     expect(dl).toBeInTheDocument();
@@ -32,14 +41,14 @@ describe("GlossarySection", () => {
   });
 
   it("각 용어에 올바른 id 앵커가 설정된다", () => {
-    render(<GlossarySection entries={mockEntries} />);
+    renderWithProvider();
 
     expect(document.getElementById("glossary-closure")).toBeInTheDocument();
     expect(document.getElementById("glossary-lexical-scope")).toBeInTheDocument();
   });
 
   it("용어 이름과 상세 설명이 표시된다", () => {
-    render(<GlossarySection entries={mockEntries} />);
+    renderWithProvider();
 
     expect(screen.getByText("클로저(Closure)")).toBeInTheDocument();
     expect(
@@ -50,29 +59,70 @@ describe("GlossarySection", () => {
   });
 
   it("빈 배열이면 null을 반환한다 (렌더링하지 않는다)", () => {
-    const { container } = render(<GlossarySection entries={[]} />);
-    expect(container.innerHTML).toBe("");
+    const { container } = render(
+      <GlossaryProvider entries={[]}>
+        <GlossarySection entries={[]} />
+      </GlossaryProvider>
+    );
+    expect(container.querySelector(".glossary-section")).toBeNull();
   });
 
   it("section에 role=doc-endnotes와 aria-label이 설정된다", () => {
-    render(<GlossarySection entries={mockEntries} />);
+    renderWithProvider();
 
     const section = screen.getByRole("doc-endnotes");
     expect(section).toHaveAttribute("aria-label", "용어 설명");
   });
 
   it("섹션 제목이 표시된다", () => {
-    render(<GlossarySection entries={mockEntries} />);
+    renderWithProvider();
 
     expect(screen.getByText("용어 설명")).toBeInTheDocument();
   });
 
   it("본문으로 돌아가기 링크가 각 용어에 포함된다", () => {
-    render(<GlossarySection entries={mockEntries} />);
+    renderWithProvider();
 
     const backLinks = screen.getAllByLabelText("본문으로 돌아가기");
     expect(backLinks).toHaveLength(2);
     expect(backLinks[0]).toHaveAttribute("href", "#term-closure");
     expect(backLinks[1]).toHaveAttribute("href", "#term-lexical-scope");
+  });
+
+  it("토글 버튼이 존재하고 aria-expanded가 설정된다", () => {
+    renderWithProvider();
+
+    const toggleButton = screen.getByRole("button", {
+      name: "용어 설명 접기/펼치기",
+    });
+    expect(toggleButton).toBeInTheDocument();
+    expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("토글 버튼 클릭 시 용어 목록이 접힌다", () => {
+    const { container } = renderWithProvider();
+
+    const toggleButton = screen.getByRole("button", {
+      name: "용어 설명 접기/펼치기",
+    });
+    fireEvent.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+    const list = container.querySelector(".glossary-list");
+    expect(list).toHaveClass("glossary-list-closed");
+  });
+
+  it("접힌 상태에서 다시 클릭하면 펼쳐진다", () => {
+    const { container } = renderWithProvider();
+
+    const toggleButton = screen.getByRole("button", {
+      name: "용어 설명 접기/펼치기",
+    });
+    fireEvent.click(toggleButton); // 접기
+    fireEvent.click(toggleButton); // 펼치기
+
+    expect(toggleButton).toHaveAttribute("aria-expanded", "true");
+    const list = container.querySelector(".glossary-list");
+    expect(list).toHaveClass("glossary-list-open");
   });
 });

--- a/src/components/__tests__/GlossarySection.test.tsx
+++ b/src/components/__tests__/GlossarySection.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { GlossarySection } from "../glossary/GlossarySection";
+import type { GlossaryEntry } from "@/types";
+
+const mockEntries: GlossaryEntry[] = [
+  {
+    id: "closure",
+    term: "클로저(Closure)",
+    brief: "함수가 렉시컬 환경을 기억하는 현상",
+    detail: "함수가 자신이 선언된 환경의 변수를 기억한다.",
+  },
+  {
+    id: "lexical-scope",
+    term: "렉시컬 스코프(Lexical Scope)",
+    brief: "선언 위치에 따라 스코프가 결정되는 규칙",
+    detail: "정적 스코프라고도 한다.",
+  },
+];
+
+describe("GlossarySection", () => {
+  it("용어 목록을 dl/dt/dd 태그로 렌더링한다", () => {
+    const { container } = render(<GlossarySection entries={mockEntries} />);
+
+    const dl = container.querySelector("dl");
+    expect(dl).toBeInTheDocument();
+
+    const dts = container.querySelectorAll("dt");
+    expect(dts).toHaveLength(2);
+
+    const dds = container.querySelectorAll("dd");
+    expect(dds).toHaveLength(2);
+  });
+
+  it("각 용어에 올바른 id 앵커가 설정된다", () => {
+    render(<GlossarySection entries={mockEntries} />);
+
+    expect(document.getElementById("glossary-closure")).toBeInTheDocument();
+    expect(document.getElementById("glossary-lexical-scope")).toBeInTheDocument();
+  });
+
+  it("용어 이름과 상세 설명이 표시된다", () => {
+    render(<GlossarySection entries={mockEntries} />);
+
+    expect(screen.getByText("클로저(Closure)")).toBeInTheDocument();
+    expect(
+      screen.getByText("함수가 자신이 선언된 환경의 변수를 기억한다.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("렉시컬 스코프(Lexical Scope)")).toBeInTheDocument();
+    expect(screen.getByText("정적 스코프라고도 한다.")).toBeInTheDocument();
+  });
+
+  it("빈 배열이면 null을 반환한다 (렌더링하지 않는다)", () => {
+    const { container } = render(<GlossarySection entries={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("section에 role=doc-endnotes와 aria-label이 설정된다", () => {
+    render(<GlossarySection entries={mockEntries} />);
+
+    const section = screen.getByRole("doc-endnotes");
+    expect(section).toHaveAttribute("aria-label", "용어 설명");
+  });
+
+  it("섹션 제목이 표시된다", () => {
+    render(<GlossarySection entries={mockEntries} />);
+
+    expect(screen.getByText("용어 설명")).toBeInTheDocument();
+  });
+
+  it("본문으로 돌아가기 링크가 각 용어에 포함된다", () => {
+    render(<GlossarySection entries={mockEntries} />);
+
+    const backLinks = screen.getAllByLabelText("본문으로 돌아가기");
+    expect(backLinks).toHaveLength(2);
+    expect(backLinks[0]).toHaveAttribute("href", "#term-closure");
+    expect(backLinks[1]).toHaveAttribute("href", "#term-lexical-scope");
+  });
+});

--- a/src/components/__tests__/Term.test.tsx
+++ b/src/components/__tests__/Term.test.tsx
@@ -100,7 +100,7 @@ describe("Term", () => {
     jest.restoreAllMocks();
   });
 
-  it("스크롤 완료 후 대상 용어 설명 항목에 강조 애니메이션을 적용한다", () => {
+  it("스크롤 완료 후 대상 용어 설명 항목에 배경 강조를 적용한다", () => {
     Object.defineProperty(window, "onscrollend", {
       value: null,
       writable: true,
@@ -123,7 +123,7 @@ describe("Term", () => {
 
     window.dispatchEvent(new Event("scrollend"));
 
-    expect(mockClassList.add).toHaveBeenCalledWith("glossary-highlight");
+    expect(mockClassList.add).toHaveBeenCalledWith("glossary-entry-highlight");
 
     delete (window as Record<string, unknown>)["onscrollend"];
     jest.restoreAllMocks();

--- a/src/components/__tests__/Term.test.tsx
+++ b/src/components/__tests__/Term.test.tsx
@@ -85,7 +85,8 @@ describe("Term", () => {
 
   it("클릭 시 glossary 섹션으로 스크롤한다", () => {
     const mockScrollIntoView = jest.fn();
-    const mockElement = { scrollIntoView: mockScrollIntoView };
+    const mockClassList = { add: jest.fn(), remove: jest.fn() };
+    const mockElement = { scrollIntoView: mockScrollIntoView, classList: mockClassList };
     jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
 
     renderWithProvider(<Term id="closure">클로저</Term>);
@@ -99,9 +100,39 @@ describe("Term", () => {
     jest.restoreAllMocks();
   });
 
+  it("스크롤 완료 후 대상 용어 설명 항목에 강조 애니메이션을 적용한다", () => {
+    Object.defineProperty(window, "onscrollend", {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    const mockClassList = { add: jest.fn(), remove: jest.fn() };
+    const mockElement = {
+      scrollIntoView: jest.fn(),
+      classList: mockClassList,
+    };
+    jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
+
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.click(abbr);
+
+    expect(mockClassList.add).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event("scrollend"));
+
+    expect(mockClassList.add).toHaveBeenCalledWith("glossary-highlight");
+
+    delete (window as Record<string, unknown>)["onscrollend"];
+    jest.restoreAllMocks();
+  });
+
   it("Enter 키 누르면 glossary 섹션으로 스크롤한다", () => {
     const mockScrollIntoView = jest.fn();
-    const mockElement = { scrollIntoView: mockScrollIntoView };
+    const mockClassList = { add: jest.fn(), remove: jest.fn() };
+    const mockElement = { scrollIntoView: mockScrollIntoView, classList: mockClassList };
     jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
 
     renderWithProvider(<Term id="closure">클로저</Term>);

--- a/src/components/__tests__/Term.test.tsx
+++ b/src/components/__tests__/Term.test.tsx
@@ -25,10 +25,29 @@ describe("Term", () => {
     expect(abbr.tagName).toBe("ABBR");
   });
 
-  it("aria-describedby 속성이 올바르게 설정된다", () => {
+  it("기본 aria-describedby가 glossary 섹션을 가리킨다", () => {
     renderWithProvider(<Term id="closure">클로저</Term>);
 
     const abbr = screen.getByText("클로저");
+    expect(abbr).toHaveAttribute("aria-describedby", "glossary-closure");
+  });
+
+  it("호버 시 aria-describedby가 툴팁으로 전환된다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.mouseEnter(abbr);
+
+    expect(abbr).toHaveAttribute("aria-describedby", "tooltip-closure");
+  });
+
+  it("마우스 아웃 시 aria-describedby가 glossary로 복원된다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.mouseEnter(abbr);
+    fireEvent.mouseLeave(abbr);
+
     expect(abbr).toHaveAttribute("aria-describedby", "glossary-closure");
   });
 

--- a/src/components/__tests__/Term.test.tsx
+++ b/src/components/__tests__/Term.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Term } from "../glossary/Term";
+import { GlossaryProvider } from "../glossary/GlossaryProvider";
+import type { GlossaryEntry } from "@/types";
+
+const mockEntries: GlossaryEntry[] = [
+  {
+    id: "closure",
+    term: "클로저(Closure)",
+    brief: "함수가 렉시컬 환경을 기억하는 현상",
+    detail: "함수가 자신이 선언된 환경의 변수를 기억한다.",
+  },
+];
+
+function renderWithProvider(ui: React.ReactElement, entries = mockEntries) {
+  return render(<GlossaryProvider entries={entries}>{ui}</GlossaryProvider>);
+}
+
+describe("Term", () => {
+  it("용어가 Context에 존재하면 abbr 태그로 렌더링한다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    expect(abbr.tagName).toBe("ABBR");
+  });
+
+  it("aria-describedby 속성이 올바르게 설정된다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    expect(abbr).toHaveAttribute("aria-describedby", "glossary-closure");
+  });
+
+  it("role=doc-noteref 속성이 설정된다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    expect(abbr).toHaveAttribute("role", "doc-noteref");
+  });
+
+  it("tabIndex=0으로 키보드 포커스가 가능하다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    expect(abbr).toHaveAttribute("tabindex", "0");
+  });
+
+  it("용어가 Context에 없으면 일반 span으로 렌더링한다", () => {
+    renderWithProvider(<Term id="nonexistent">알 수 없는 용어</Term>);
+
+    const span = screen.getByText("알 수 없는 용어");
+    expect(span.tagName).toBe("SPAN");
+  });
+
+  it("호버 시 툴팁이 표시된다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.mouseEnter(abbr);
+
+    expect(
+      screen.getByText("함수가 렉시컬 환경을 기억하는 현상")
+    ).toBeInTheDocument();
+  });
+
+  it("마우스 아웃 시 툴팁이 사라진다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.mouseEnter(abbr);
+    fireEvent.mouseLeave(abbr);
+
+    expect(
+      screen.queryByText("함수가 렉시컬 환경을 기억하는 현상")
+    ).not.toBeInTheDocument();
+  });
+
+  it("클릭 시 glossary 섹션으로 스크롤한다", () => {
+    const mockScrollIntoView = jest.fn();
+    const mockElement = { scrollIntoView: mockScrollIntoView };
+    jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
+
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.click(abbr);
+
+    expect(document.getElementById).toHaveBeenCalledWith("glossary-closure");
+    expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+
+    jest.restoreAllMocks();
+  });
+
+  it("Enter 키 누르면 glossary 섹션으로 스크롤한다", () => {
+    const mockScrollIntoView = jest.fn();
+    const mockElement = { scrollIntoView: mockScrollIntoView };
+    jest.spyOn(document, "getElementById").mockReturnValue(mockElement as unknown as HTMLElement);
+
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    fireEvent.keyDown(abbr, { key: "Enter" });
+
+    expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+
+    jest.restoreAllMocks();
+  });
+});

--- a/src/components/__tests__/Term.test.tsx
+++ b/src/components/__tests__/Term.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { Term } from "../glossary/Term";
 import { GlossaryProvider } from "../glossary/GlossaryProvider";
+import { GlossarySection } from "../glossary/GlossarySection";
 import type { GlossaryEntry } from "@/types";
 
 const mockEntries: GlossaryEntry[] = [
@@ -43,6 +44,13 @@ describe("Term", () => {
 
     const abbr = screen.getByText("클로저");
     expect(abbr).toHaveAttribute("tabindex", "0");
+  });
+
+  it("역참조 앵커 타겟으로 사용할 id가 설정된다", () => {
+    renderWithProvider(<Term id="closure">클로저</Term>);
+
+    const abbr = screen.getByText("클로저");
+    expect(abbr).toHaveAttribute("id", "term-closure");
   });
 
   it("용어가 Context에 없으면 일반 span으로 렌더링한다", () => {
@@ -104,5 +112,29 @@ describe("Term", () => {
     expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
 
     jest.restoreAllMocks();
+  });
+
+  it("클릭 시 접힌 GlossarySection이 자동으로 열린다", () => {
+    Element.prototype.scrollIntoView = jest.fn();
+
+    render(
+      <GlossaryProvider entries={mockEntries}>
+        <Term id="closure">클로저</Term>
+        <GlossarySection entries={mockEntries} />
+      </GlossaryProvider>
+    );
+
+    // 섹션 접기
+    const toggleButton = screen.getByRole("button", {
+      name: "용어 설명 접기/펼치기",
+    });
+    fireEvent.click(toggleButton);
+    expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+
+    // Term 클릭 → 접힌 섹션이 자동으로 열려야 함
+    const abbr = screen.getByText("클로저");
+    fireEvent.click(abbr);
+
+    expect(toggleButton).toHaveAttribute("aria-expanded", "true");
   });
 });

--- a/src/components/glossary/GlossaryProvider.tsx
+++ b/src/components/glossary/GlossaryProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+import type { GlossaryEntry } from "@/types";
+
+const GlossaryContext = createContext<Map<string, GlossaryEntry>>(new Map());
+
+interface GlossaryProviderProps {
+  entries: GlossaryEntry[];
+  children: React.ReactNode;
+}
+
+export function GlossaryProvider({ entries, children }: GlossaryProviderProps) {
+  const entryMap = useMemo(
+    () => new Map(entries.map((entry) => [entry.id, entry])),
+    [entries]
+  );
+
+  return (
+    <GlossaryContext.Provider value={entryMap}>
+      {children}
+    </GlossaryContext.Provider>
+  );
+}
+
+export function useGlossary(id: string): GlossaryEntry | undefined {
+  const map = useContext(GlossaryContext);
+  return map.get(id);
+}

--- a/src/components/glossary/GlossarySection.tsx
+++ b/src/components/glossary/GlossarySection.tsx
@@ -1,0 +1,42 @@
+import type { GlossaryEntry } from "@/types";
+
+interface GlossarySectionProps {
+  entries: GlossaryEntry[];
+}
+
+export function GlossarySection({ entries }: GlossarySectionProps) {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className="glossary-section"
+      role="doc-endnotes"
+      aria-label="용어 설명"
+    >
+      <h2 className="glossary-section-title">용어 설명</h2>
+      <dl className="glossary-list">
+        {entries.map((entry) => (
+          <div
+            key={entry.id}
+            id={`glossary-${entry.id}`}
+            className="glossary-item"
+          >
+            <dt className="glossary-item-term">
+              {entry.term}
+              <a
+                href={`#term-${entry.id}`}
+                className="glossary-back-link"
+                aria-label="본문으로 돌아가기"
+              >
+                ↑
+              </a>
+            </dt>
+            <dd className="glossary-item-detail">{entry.detail}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/glossary/GlossarySection.tsx
+++ b/src/components/glossary/GlossarySection.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useCallback } from "react";
 import type { GlossaryEntry } from "@/types";
 import { useGlossarySection } from "./GlossaryProvider";
+import { scrollAndHighlight } from "@/lib/scrollHighlight";
 
 interface GlossarySectionProps {
   entries: GlossaryEntry[];
@@ -9,6 +11,12 @@ interface GlossarySectionProps {
 
 export function GlossarySection({ entries }: GlossarySectionProps) {
   const { isSectionOpen, toggleSection } = useGlossarySection();
+
+  const handleBackToTerm = useCallback((e: React.MouseEvent, termId: string) => {
+    e.preventDefault();
+    const target = document.getElementById(`term-${termId}`);
+    scrollAndHighlight(target);
+  }, []);
 
   if (entries.length === 0) {
     return null;
@@ -55,6 +63,7 @@ export function GlossarySection({ entries }: GlossarySectionProps) {
                 href={`#term-${entry.id}`}
                 className="glossary-back-link"
                 aria-label="본문으로 돌아가기"
+                onClick={(e) => handleBackToTerm(e, entry.id)}
               >
                 ↑
               </a>

--- a/src/components/glossary/GlossarySection.tsx
+++ b/src/components/glossary/GlossarySection.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import type { GlossaryEntry } from "@/types";
+import { useGlossarySection } from "./GlossaryProvider";
 
 interface GlossarySectionProps {
   entries: GlossaryEntry[];
 }
 
 export function GlossarySection({ entries }: GlossarySectionProps) {
+  const { isSectionOpen, toggleSection } = useGlossarySection();
+
   if (entries.length === 0) {
     return null;
   }
@@ -15,8 +20,29 @@ export function GlossarySection({ entries }: GlossarySectionProps) {
       role="doc-endnotes"
       aria-label="용어 설명"
     >
-      <h2 className="glossary-section-title">용어 설명</h2>
-      <dl className="glossary-list">
+      <button
+        onClick={toggleSection}
+        aria-expanded={isSectionOpen}
+        aria-label="용어 설명 접기/펼치기"
+        className="glossary-toggle-button"
+      >
+        <h2 className="glossary-section-title">용어 설명</h2>
+        <svg
+          className={`glossary-toggle-icon ${isSectionOpen ? "rotate-0" : "-rotate-90"}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+      <dl className={`glossary-list ${isSectionOpen ? "glossary-list-open" : "glossary-list-closed"}`}>
         {entries.map((entry) => (
           <div
             key={entry.id}

--- a/src/components/glossary/Term.tsx
+++ b/src/components/glossary/Term.tsx
@@ -39,7 +39,7 @@ export function Term({ id, children }: TermProps) {
       id={`term-${id}`}
       className="glossary-term"
       role="doc-noteref"
-      aria-describedby={`glossary-${id}`}
+      aria-describedby={showTooltip ? `tooltip-${id}` : `glossary-${id}`}
       tabIndex={0}
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}

--- a/src/components/glossary/Term.tsx
+++ b/src/components/glossary/Term.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useGlossary } from "./GlossaryProvider";
+
+interface TermProps {
+  id: string;
+  children: React.ReactNode;
+}
+
+export function Term({ id, children }: TermProps) {
+  const entry = useGlossary(id);
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const handleScrollToGlossary = useCallback(() => {
+    const target = document.getElementById(`glossary-${id}`);
+    target?.scrollIntoView({ behavior: "smooth" });
+  }, [id]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleScrollToGlossary();
+      }
+    },
+    [handleScrollToGlossary]
+  );
+
+  if (!entry) {
+    return <span>{children}</span>;
+  }
+
+  return (
+    <abbr
+      className="glossary-term"
+      role="doc-noteref"
+      aria-describedby={`glossary-${id}`}
+      tabIndex={0}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+      onFocus={() => setShowTooltip(true)}
+      onBlur={() => setShowTooltip(false)}
+      onClick={handleScrollToGlossary}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+      {showTooltip && (
+        <span className="glossary-tooltip" role="tooltip" id={`tooltip-${id}`}>
+          {entry.brief}
+          <span className="glossary-tooltip-more">자세히 보기 ↓</span>
+        </span>
+      )}
+    </abbr>
+  );
+}

--- a/src/components/glossary/Term.tsx
+++ b/src/components/glossary/Term.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { useGlossary, useGlossarySection } from "./GlossaryProvider";
+import { scrollAndHighlight } from "@/lib/scrollHighlight";
 
 interface TermProps {
   id: string;
@@ -16,7 +17,7 @@ export function Term({ id, children }: TermProps) {
   const handleScrollToGlossary = useCallback(() => {
     openSection();
     const target = document.getElementById(`glossary-${id}`);
-    target?.scrollIntoView({ behavior: "smooth" });
+    scrollAndHighlight(target);
   }, [id, openSection]);
 
   const handleKeyDown = useCallback(

--- a/src/components/glossary/Term.tsx
+++ b/src/components/glossary/Term.tsx
@@ -17,7 +17,7 @@ export function Term({ id, children }: TermProps) {
   const handleScrollToGlossary = useCallback(() => {
     openSection();
     const target = document.getElementById(`glossary-${id}`);
-    scrollAndHighlight(target);
+    scrollAndHighlight(target, "glossary-entry-highlight");
   }, [id, openSection]);
 
   const handleKeyDown = useCallback(

--- a/src/components/glossary/Term.tsx
+++ b/src/components/glossary/Term.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { useGlossary } from "./GlossaryProvider";
+import { useGlossary, useGlossarySection } from "./GlossaryProvider";
 
 interface TermProps {
   id: string;
@@ -10,12 +10,14 @@ interface TermProps {
 
 export function Term({ id, children }: TermProps) {
   const entry = useGlossary(id);
+  const { openSection } = useGlossarySection();
   const [showTooltip, setShowTooltip] = useState(false);
 
   const handleScrollToGlossary = useCallback(() => {
+    openSection();
     const target = document.getElementById(`glossary-${id}`);
     target?.scrollIntoView({ behavior: "smooth" });
-  }, [id]);
+  }, [id, openSection]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -33,6 +35,7 @@ export function Term({ id, children }: TermProps) {
 
   return (
     <abbr
+      id={`term-${id}`}
       className="glossary-term"
       role="doc-noteref"
       aria-describedby={`glossary-${id}`}

--- a/src/components/glossary/index.ts
+++ b/src/components/glossary/index.ts
@@ -1,0 +1,3 @@
+export { GlossaryProvider } from "./GlossaryProvider";
+export { Term } from "./Term";
+export { GlossarySection } from "./GlossarySection";

--- a/src/lib/__tests__/glossary.test.ts
+++ b/src/lib/__tests__/glossary.test.ts
@@ -68,6 +68,35 @@ describe("parseGlossary", () => {
     expect(result[0]).toEqual(validEntry);
   });
 
+  it("id가 HTML-safe 패턴이 아닌 항목은 제외한다", () => {
+    const raw = [
+      validEntry,
+      { id: "has space", term: "공백", brief: "설명", detail: "상세" },
+      { id: "has\"quote", term: "따옴표", brief: "설명", detail: "상세" },
+      { id: "has>angle", term: "꺾쇠", brief: "설명", detail: "상세" },
+      { id: "", term: "빈ID", brief: "설명", detail: "상세" },
+      { id: "-leading-dash", term: "대시시작", brief: "설명", detail: "상세" },
+      { id: "trailing-dash-", term: "대시끝", brief: "설명", detail: "상세" },
+      { id: "UPPERCASE", term: "대문자", brief: "설명", detail: "상세" },
+    ];
+
+    const result = parseGlossary(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(validEntry);
+  });
+
+  it("유효한 id 패턴은 통과한다", () => {
+    const raw = [
+      { id: "closure", term: "클로저", brief: "설명", detail: "상세" },
+      { id: "lexical-scope", term: "스코프", brief: "설명", detail: "상세" },
+      { id: "es6", term: "ES6", brief: "설명", detail: "상세" },
+      { id: "web-api-v2", term: "API", brief: "설명", detail: "상세" },
+    ];
+
+    const result = parseGlossary(raw);
+    expect(result).toHaveLength(4);
+  });
+
   it("배열 내 null/undefined 항목은 제외한다", () => {
     const raw = [validEntry, null, undefined, validEntry2];
 

--- a/src/lib/__tests__/glossary.test.ts
+++ b/src/lib/__tests__/glossary.test.ts
@@ -1,0 +1,79 @@
+import { parseGlossary } from "../glossary";
+import type { GlossaryEntry } from "@/types";
+
+describe("parseGlossary", () => {
+  const validEntry: GlossaryEntry = {
+    id: "closure",
+    term: "클로저(Closure)",
+    brief: "함수가 선언된 렉시컬 환경을 기억하는 현상",
+    detail: "함수가 자신이 선언된 환경의 변수를 기억하고, 외부 함수 실행이 종료된 후에도 해당 변수에 접근할 수 있는 메커니즘이다.",
+  };
+
+  const validEntry2: GlossaryEntry = {
+    id: "lexical-scope",
+    term: "렉시컬 스코프(Lexical Scope)",
+    brief: "함수 선언 위치에 따라 스코프가 결정되는 규칙",
+    detail: "정적 스코프라고도 한다.",
+  };
+
+  it("정상 데이터를 GlossaryEntry 배열로 파싱한다", () => {
+    const raw = [validEntry, validEntry2];
+    const result = parseGlossary(raw);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(validEntry);
+    expect(result[1]).toEqual(validEntry2);
+  });
+
+  it("undefined 입력 시 빈 배열을 반환한다", () => {
+    expect(parseGlossary(undefined)).toEqual([]);
+  });
+
+  it("null 입력 시 빈 배열을 반환한다", () => {
+    expect(parseGlossary(null)).toEqual([]);
+  });
+
+  it("빈 배열 입력 시 빈 배열을 반환한다", () => {
+    expect(parseGlossary([])).toEqual([]);
+  });
+
+  it("배열이 아닌 입력 시 빈 배열을 반환한다", () => {
+    expect(parseGlossary("not an array")).toEqual([]);
+    expect(parseGlossary(42)).toEqual([]);
+    expect(parseGlossary({})).toEqual([]);
+  });
+
+  it("필수 필드가 누락된 항목은 제외한다", () => {
+    const raw = [
+      validEntry,
+      { id: "missing-term", brief: "설명", detail: "상세" }, // term 누락
+      { term: "누락", brief: "설명", detail: "상세" }, // id 누락
+      { id: "missing-brief", term: "테스트", detail: "상세" }, // brief 누락
+      { id: "missing-detail", term: "테스트", brief: "설명" }, // detail 누락
+    ];
+
+    const result = parseGlossary(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(validEntry);
+  });
+
+  it("필수 필드가 문자열이 아닌 항목은 제외한다", () => {
+    const raw = [
+      validEntry,
+      { id: 123, term: "숫자ID", brief: "설명", detail: "상세" },
+    ];
+
+    const result = parseGlossary(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(validEntry);
+  });
+
+  it("배열 내 null/undefined 항목은 제외한다", () => {
+    const raw = [validEntry, null, undefined, validEntry2];
+
+    const result = parseGlossary(raw);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(validEntry);
+    expect(result[1]).toEqual(validEntry2);
+  });
+});

--- a/src/lib/__tests__/scrollHighlight.test.ts
+++ b/src/lib/__tests__/scrollHighlight.test.ts
@@ -1,0 +1,144 @@
+import { scrollAndHighlight } from "../scrollHighlight";
+
+describe("scrollAndHighlight", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("target이 null이면 아무 동작도 하지 않는다", () => {
+    expect(() => scrollAndHighlight(null)).not.toThrow();
+  });
+
+  it("scrollIntoView를 smooth behavior로 호출한다", () => {
+    const target = createMockElement();
+
+    scrollAndHighlight(target);
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth" });
+  });
+
+  describe("scrollend 지원 환경", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "onscrollend", {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      delete (window as Record<string, unknown>)["onscrollend"];
+    });
+
+    it("scrollend 이벤트 발생 후 강조 클래스를 추가한다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+
+      expect(target.classList.add).not.toHaveBeenCalled();
+
+      window.dispatchEvent(new Event("scrollend"));
+
+      expect(target.classList.add).toHaveBeenCalledWith("glossary-highlight");
+    });
+
+    it("강조 클래스는 1500ms 후 제거된다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+      window.dispatchEvent(new Event("scrollend"));
+
+      expect(target.classList.remove).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1500);
+
+      expect(target.classList.remove).toHaveBeenCalledWith("glossary-highlight");
+    });
+
+    it("scrollend 미발생 시 1000ms 안전 타임아웃으로 강조를 적용한다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+
+      expect(target.classList.add).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1000);
+
+      expect(target.classList.add).toHaveBeenCalledWith("glossary-highlight");
+    });
+
+    it("scrollend와 안전 타임아웃 중 먼저 발생한 것만 적용된다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+      window.dispatchEvent(new Event("scrollend"));
+
+      jest.advanceTimersByTime(1000);
+
+      expect(target.classList.add).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("scrollend 미지원 환경", () => {
+    it("500ms 후 강조 클래스를 추가한다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+
+      expect(target.classList.add).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(500);
+
+      expect(target.classList.add).toHaveBeenCalledWith("glossary-highlight");
+    });
+
+    it("강조 클래스는 1500ms 후 제거된다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+      jest.advanceTimersByTime(500);
+
+      expect(target.classList.remove).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1500);
+
+      expect(target.classList.remove).toHaveBeenCalledWith("glossary-highlight");
+    });
+  });
+
+  it("커스텀 클래스명을 지원한다", () => {
+    Object.defineProperty(window, "onscrollend", {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    const target = createMockElement();
+
+    scrollAndHighlight(target, "heading-highlight");
+    window.dispatchEvent(new Event("scrollend"));
+
+    expect(target.classList.add).toHaveBeenCalledWith("heading-highlight");
+
+    jest.advanceTimersByTime(1500);
+
+    expect(target.classList.remove).toHaveBeenCalledWith("heading-highlight");
+
+    delete (window as Record<string, unknown>)["onscrollend"];
+  });
+});
+
+function createMockElement(): HTMLElement {
+  return {
+    scrollIntoView: jest.fn(),
+    classList: {
+      add: jest.fn(),
+      remove: jest.fn(),
+    },
+  } as unknown as HTMLElement;
+}

--- a/src/lib/__tests__/scrollHighlight.test.ts
+++ b/src/lib/__tests__/scrollHighlight.test.ts
@@ -91,6 +91,19 @@ describe("scrollAndHighlight", () => {
 
       expect(target.classList.add).toHaveBeenCalledTimes(1);
     });
+
+    it("scrollend 발생 시 안전 타임아웃이 취소된다", () => {
+      const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
+
+      const target = createMockElement();
+      scrollAndHighlight(target);
+
+      window.dispatchEvent(new Event("scrollend"));
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+
+      clearTimeoutSpy.mockRestore();
+    });
   });
 
   describe("scrollend 미지원 환경", () => {

--- a/src/lib/__tests__/scrollHighlight.test.ts
+++ b/src/lib/__tests__/scrollHighlight.test.ts
@@ -47,15 +47,24 @@ describe("scrollAndHighlight", () => {
       expect(target.classList.add).toHaveBeenCalledWith("glossary-highlight");
     });
 
-    it("강조 클래스는 1500ms 후 제거된다", () => {
+    it("강조 클래스는 1500ms 시점에서는 아직 제거되지 않는다", () => {
       const target = createMockElement();
 
       scrollAndHighlight(target);
       window.dispatchEvent(new Event("scrollend"));
 
-      expect(target.classList.remove).not.toHaveBeenCalled();
-
       jest.advanceTimersByTime(1500);
+
+      expect(target.classList.remove).not.toHaveBeenCalled();
+    });
+
+    it("강조 클래스는 2000ms 후 제거된다", () => {
+      const target = createMockElement();
+
+      scrollAndHighlight(target);
+      window.dispatchEvent(new Event("scrollend"));
+
+      jest.advanceTimersByTime(2000);
 
       expect(target.classList.remove).toHaveBeenCalledWith("glossary-highlight");
     });
@@ -97,7 +106,7 @@ describe("scrollAndHighlight", () => {
       expect(target.classList.add).toHaveBeenCalledWith("glossary-highlight");
     });
 
-    it("강조 클래스는 1500ms 후 제거된다", () => {
+    it("강조 클래스는 2000ms 후 제거된다", () => {
       const target = createMockElement();
 
       scrollAndHighlight(target);
@@ -105,7 +114,7 @@ describe("scrollAndHighlight", () => {
 
       expect(target.classList.remove).not.toHaveBeenCalled();
 
-      jest.advanceTimersByTime(1500);
+      jest.advanceTimersByTime(2000);
 
       expect(target.classList.remove).toHaveBeenCalledWith("glossary-highlight");
     });
@@ -125,7 +134,7 @@ describe("scrollAndHighlight", () => {
 
     expect(target.classList.add).toHaveBeenCalledWith("heading-highlight");
 
-    jest.advanceTimersByTime(1500);
+    jest.advanceTimersByTime(2000);
 
     expect(target.classList.remove).toHaveBeenCalledWith("heading-highlight");
 

--- a/src/lib/glossary.ts
+++ b/src/lib/glossary.ts
@@ -12,6 +12,8 @@ export function parseGlossary(data: unknown): GlossaryEntry[] {
   return data.filter(isValidGlossaryEntry);
 }
 
+const VALID_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 function isValidGlossaryEntry(item: unknown): item is GlossaryEntry {
   if (item == null || typeof item !== "object") {
     return false;
@@ -21,6 +23,7 @@ function isValidGlossaryEntry(item: unknown): item is GlossaryEntry {
 
   return (
     typeof entry.id === "string" &&
+    VALID_ID_PATTERN.test(entry.id) &&
     typeof entry.term === "string" &&
     typeof entry.brief === "string" &&
     typeof entry.detail === "string"

--- a/src/lib/glossary.ts
+++ b/src/lib/glossary.ts
@@ -1,0 +1,28 @@
+import type { GlossaryEntry } from "@/types";
+
+/**
+ * frontmatter의 raw glossary 데이터를 GlossaryEntry 배열로 파싱한다.
+ * 유효하지 않은 항목은 제외한다.
+ */
+export function parseGlossary(data: unknown): GlossaryEntry[] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.filter(isValidGlossaryEntry);
+}
+
+function isValidGlossaryEntry(item: unknown): item is GlossaryEntry {
+  if (item == null || typeof item !== "object") {
+    return false;
+  }
+
+  const entry = item as Record<string, unknown>;
+
+  return (
+    typeof entry.id === "string" &&
+    typeof entry.term === "string" &&
+    typeof entry.brief === "string" &&
+    typeof entry.detail === "string"
+  );
+}

--- a/src/lib/scrollHighlight.ts
+++ b/src/lib/scrollHighlight.ts
@@ -10,7 +10,7 @@ export function scrollAndHighlight(
     target.classList.add(highlightClass);
     setTimeout(() => {
       target.classList.remove(highlightClass);
-    }, 1500);
+    }, 2000);
   };
 
   if ("onscrollend" in window) {

--- a/src/lib/scrollHighlight.ts
+++ b/src/lib/scrollHighlight.ts
@@ -1,0 +1,33 @@
+export function scrollAndHighlight(
+  target: HTMLElement | null,
+  highlightClass: string = "glossary-highlight"
+): void {
+  if (!target) return;
+
+  target.scrollIntoView({ behavior: "smooth" });
+
+  const applyHighlight = () => {
+    target.classList.add(highlightClass);
+    setTimeout(() => {
+      target.classList.remove(highlightClass);
+    }, 1500);
+  };
+
+  if ("onscrollend" in window) {
+    let applied = false;
+    const handler = () => {
+      if (applied) return;
+      applied = true;
+      applyHighlight();
+    };
+    window.addEventListener("scrollend", handler, { once: true });
+    setTimeout(() => {
+      if (!applied) {
+        window.removeEventListener("scrollend", handler);
+        handler();
+      }
+    }, 1000);
+  } else {
+    setTimeout(applyHighlight, 500);
+  }
+}

--- a/src/lib/scrollHighlight.ts
+++ b/src/lib/scrollHighlight.ts
@@ -18,10 +18,11 @@ export function scrollAndHighlight(
     const handler = () => {
       if (applied) return;
       applied = true;
+      clearTimeout(fallbackTimer);
       applyHighlight();
     };
     window.addEventListener("scrollend", handler, { once: true });
-    setTimeout(() => {
+    const fallbackTimer = setTimeout(() => {
       if (!applied) {
         window.removeEventListener("scrollend", handler);
         handler();

--- a/src/repositories/file-post.repository.ts
+++ b/src/repositories/file-post.repository.ts
@@ -5,6 +5,7 @@ import readingTime from "reading-time";
 import type { IPostRepository } from "@/interfaces";
 import type { Post, PostMeta, PostFrontmatter } from "@/types";
 import { POST_DEFAULTS } from "@/lib/constants";
+import { parseGlossary } from "@/lib/glossary";
 
 /**
  * 파일 시스템 기반 포스트 Repository 구현체 (Infrastructure Layer)
@@ -98,10 +99,12 @@ export class FilePostRepository implements IPostRepository {
   private parsePost(slug: string, filePath: string): Post {
     const fileContents = fs.readFileSync(filePath, "utf8");
     const { data, content } = matter(fileContents);
+    const glossary = parseGlossary((data as Record<string, unknown>).glossary);
 
     return {
       ...this.buildPostMeta(slug, data as PostFrontmatter, content),
       content,
+      ...(glossary.length > 0 && { glossary }),
     };
   }
 

--- a/src/types/glossary.ts
+++ b/src/types/glossary.ts
@@ -1,0 +1,13 @@
+/**
+ * 글로서리 용어 항목 (Domain Entity)
+ */
+export interface GlossaryEntry {
+  /** 고유 식별자 (앵커 링크용) */
+  id: string;
+  /** 용어 전체 표시명 */
+  term: string;
+  /** 툴팁에 표시할 간략 설명 */
+  brief: string;
+  /** 하단 섹션에 표시할 상세 설명 */
+  detail: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export type { Post, PostMeta, PostFrontmatter } from "./post";
+export type { GlossaryEntry } from "./glossary";
 export type { Project } from "./project";
 export type { SearchResult, SearchMatch, SearchOptions } from "./search";

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -17,6 +17,7 @@ export interface PostMeta {
  */
 export interface Post extends PostMeta {
   content: string;
+  glossary?: import("./glossary").GlossaryEntry[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- 본문 내 전문 용어에 호버 툴팁 + 클릭 시 하단 용어 설명으로 스크롤하는 글로서리 기능 구현
- GlossaryProvider(Context), Term(인라인 용어), GlossarySection(하단 목록) 컴포넌트 구성
- scrollend 이벤트 기반 scrollAndHighlight 유틸리티로 스크롤 완료 후 강조 애니메이션 적용
- 방향별 애니메이션 분리: 용어→용어 설명(배경 페이드), 용어 설명→용어(펄싱 링)

## Changes

### feat: 블로그 글 내 용어 설명 기능 추가
- `GlossaryEntry` 타입 및 `parseGlossary` 파싱 유틸 추가
- `Term` 컴포넌트: 호버 툴팁, 클릭 스크롤, 키보드/접근성 지원
- `GlossarySection` 컴포넌트: dl/dt/dd 시맨틱 마크업, 접기/펼치기 토글
- `GlossaryProvider`: React Context 기반 용어 데이터 및 섹션 상태 공유
- `page.tsx`에 MDX 커스텀 컴포넌트 통합
- `javascript-closure.md`에 4개 용어 적용

### fix: 글로서리 접기/펼치기 및 스크롤 위치 버그 수정
- Term 클릭 시 접힌 GlossarySection 자동 펼치기
- 역참조 링크(↑) NavBar 가려짐 수정 (scroll-margin-top)
- Term에 id 속성 추가로 역참조 앵커 동작 수정

### fix: 스크롤 완료 후 강조 애니메이션 적용 및 UI 개선
- `scrollend` 이벤트 기반 `scrollAndHighlight` 유틸리티 추출
- Term, GlossarySection, TableOfContents 3곳 중복 로직 통합
- 다크모드 용어 색상 통일, ↑ 화살표 가시성 향상

### fix: 강조 애니메이션 색상 및 방향별 효과 분리
- 펄싱 링 색상 amber → blue 계열로 변경
- 본문 Term → 용어 설명: 간단한 배경색 페이드
- 용어 설명 → 본문 Term: 펄싱 링(outline 확장)
- prefers-reduced-motion 접근성 대응

## Files changed
- 18 files (12 added, 6 modified)

## Test plan
- [x] 238개 전체 테스트 통과
- [x] 프로덕션 빌드 성공
- [x] Term 호버 시 툴팁 표시/숨김 확인
- [x] Term 클릭 → 용어 설명 스크롤 + 배경 페이드 확인
- [x] ↑ 클릭 → 본문 Term 스크롤 + 펄싱 링 확인
- [x] 접힌 상태에서 Term 클릭 시 자동 펼침 확인
- [x] 다크/라이트 모드 스타일 확인
- [x] 키보드 탐색 (Tab/Enter) 동작 확인

Closes #53