### PR TITLE
fix: MD 파일 변경 시 HMR 미동작 개선

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,6 @@
 import type { NextConfig } from "next";
+import path from "path";
+import fs from "fs";
 
 const nextConfig: NextConfig = {
   output: "export",
@@ -6,6 +8,40 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   trailingSlash: true,
+  // webpack 설정 공존 시 Turbopack 빌드 에러 방지용 (Next.js 16)
+  turbopack: {},
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.plugins.push({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        apply(compiler: any) {
+          compiler.hooks.afterCompile.tap(
+            "ContentWatchPlugin",
+            (compilation: any) => {
+              const contentDir = path.join(process.cwd(), "content/posts");
+
+              try {
+                if (!fs.existsSync(contentDir)) return;
+
+                const files = fs.readdirSync(contentDir);
+                for (const file of files) {
+                  if (file.endsWith(".md") || file.endsWith(".mdx")) {
+                    compilation.fileDependencies.add(
+                      path.join(contentDir, file)
+                    );
+                  }
+                }
+                compilation.contextDependencies.add(contentDir);
+              } catch {
+                // 디렉토리 접근 실패 시 감시 생략 (dev 서버는 계속 동작)
+              }
+            }
+          );
+        },
+      });
+    }
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- `content/posts/*.md` 파일 수정 시 브라우저에 자동 반영되지 않던 문제 해결
- webpack ContentWatchPlugin으로 MD 파일을 컴파일 의존성에 등록
- dev 스크립트를 `--webpack` 모드로 전환 (프로덕션 빌드는 Turbopack 유지)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `next.config.ts` | ContentWatchPlugin 추가 (dev 환경 전용) |
| `package.json` | dev 스크립트 `next dev --webpack` 으로 변경 |

## 동작 원리
1. webpack `afterCompile` 훅에서 `content/posts/*.md` 파일을 `fileDependencies`에 등록
2. `contextDependencies`에 디렉토리 자체도 등록 (새 파일 추가/삭제 감지)
3. MD 파일 변경 → webpack 재컴파일 → Server Component 재실행 → 브라우저 자동 반영

## Test plan
- [x] 기존 테스트 243개 전체 통과
- [x] 프로덕션 빌드 (`npm run build`) 정상 동작
- [x] MD 파일 수정 시 브라우저 자동 반영 확인
- [x] 새 MD 파일 추가 시 목록 자동 반영 확인

Closes #57