### PR TITLE
fix: 라이트모드에서 목차(TOC) 활성 항목 강조 스타일 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -529,6 +529,35 @@ body::before {
   pointer-events: none;
 }
 
+/* TOC Active Item Styles */
+.toc-item-active {
+  position: relative;
+  padding-left: 0.75rem;
+  background-color: rgba(251, 191, 36, 0.08);
+  border-radius: 0.375rem;
+  transition: all 0.2s ease;
+}
+
+.toc-item-active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(180deg, #f59e0b 0%, #d97706 100%);
+  border-radius: 0 2px 2px 0;
+  transition: all 0.2s ease;
+}
+
+.dark .toc-item-active {
+  background-color: rgba(96, 165, 250, 0.1);
+}
+
+.dark .toc-item-active::before {
+  background: linear-gradient(180deg, #60a5fa 0%, #3b82f6 100%);
+}
+
 /* Heading highlight animation */
 @keyframes heading-flash {
   0% {

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -113,9 +113,9 @@ export default function TableOfContents({ headings }: TableOfContentsProps) {
           >
             <a
               href={`#${slug}`}
-              className={`block py-1 transition-colors duration-200 hover:text-blue-600 dark:hover:text-blue-400 ${
+              className={`block py-1 transition-all duration-200 hover:text-blue-600 dark:hover:text-blue-400 ${
                 activeId === slug
-                  ? "font-medium text-blue-600 dark:text-blue-400"
+                  ? "font-medium text-blue-600 dark:text-blue-400 toc-item-active"
                   : "text-zinc-600 dark:text-zinc-400"
               }`}
               onClick={(e) => {


### PR DESCRIPTION
## Summary
- 라이트모드에서 TOC 활성 항목의 가독성이 떨어지는 문제 수정 (#61)
- 활성 항목에 좌측 보더 인디케이터 및 배경 하이라이트 추가
- 다크모드/라이트모드 각각에 맞는 색상 체계 적용

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `src/app/globals.css` | `.toc-item-active` 스타일 추가 (좌측 보더 + 배경 하이라이트, 라이트/다크 분리) |
| `src/components/TableOfContents.tsx` | 활성 항목에 `toc-item-active` CSS 클래스 적용, `transition-all` 변경 |

## Design

**라이트모드**:
- 좌측 보더: 앰버 그라데이션 (`#f59e0b` → `#d97706`)
- 배경: `rgba(251, 191, 36, 0.08)` - 기존 옐로우 테마와 조화

**다크모드**:
- 좌측 보더: 블루 그라데이션 (`#60a5fa` → `#3b82f6`)
- 배경: `rgba(96, 165, 250, 0.1)` - 기존 블루 텍스트와 조화

## Test plan
- [x] 라이트모드에서 TOC 활성 항목의 좌측 보더 + 배경 하이라이트 확인
- [x] 다크모드에서 TOC 활성 항목의 좌측 보더 + 배경 하이라이트 확인
- [x] 스크롤 시 활성 항목 전환 트랜지션이 부드러운지 확인
- [x] TOC 항목 클릭 시 정상 동작 확인 (스크롤 + 헤딩 강조)
- [x] TOC 접기/펼치기 기능 정상 동작 확인
- [x] h3 들여쓰기와 좌측 보더가 겹치지 않는지 확인

Closes #61