### PR TITLE
fix: 다크모드 페이지 이동 시 FOUC 플리커링 제거 (#65)

### DIFF
--- a/__tests__/components/ThemeToggle.test.tsx
+++ b/__tests__/components/ThemeToggle.test.tsx
@@ -4,10 +4,9 @@ import ThemeToggle from "@/components/ThemeToggle";
 
 describe("ThemeToggle", () => {
   beforeEach(() => {
-    // localStorage 초기화
     localStorage.clear();
-    // dark 클래스 제거
     document.documentElement.classList.remove("dark");
+    document.documentElement.classList.remove("no-transition");
   });
 
   it("컴포넌트가 정상적으로 렌더링된다", () => {
@@ -43,7 +42,7 @@ describe("ThemeToggle", () => {
   });
 
   it("클릭 시 다크모드에서 라이트모드로 전환된다", async () => {
-    // 다크모드로 설정
+    // 인라인 스크립트가 설정하는 DOM 상태를 시뮬레이션
     document.documentElement.classList.add("dark");
     localStorage.setItem("theme", "dark");
 
@@ -63,8 +62,10 @@ describe("ThemeToggle", () => {
     });
   });
 
-  it("localStorage에 저장된 테마를 불러온다", async () => {
+  it("DOM에서 다크모드 상태를 읽어온다 (인라인 스크립트가 설정한 상태)", async () => {
+    // 인라인 스크립트가 localStorage 기반으로 .dark 클래스를 미리 적용한 상태를 시뮬레이션
     localStorage.setItem("theme", "dark");
+    document.documentElement.classList.add("dark");
 
     render(<ThemeToggle />);
 
@@ -73,26 +74,23 @@ describe("ThemeToggle", () => {
     });
   });
 
-  it("저장된 테마가 없을 때 시스템 설정을 감지한다", async () => {
-    // prefers-color-scheme 모킹
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: query === "(prefers-color-scheme: dark)",
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
+  it("DOM에 dark 클래스가 없으면 라이트모드로 동기화된다", async () => {
+    // 인라인 스크립트가 라이트모드로 결정한 상태
+    render(<ThemeToggle />);
+
+    await waitFor(() => {
+      expect(document.documentElement).not.toHaveClass("dark");
     });
+  });
+
+  it("마운트 후 no-transition 클래스를 제거한다", async () => {
+    // 인라인 스크립트가 설정하는 no-transition 상태를 시뮬레이션
+    document.documentElement.classList.add("no-transition");
 
     render(<ThemeToggle />);
 
     await waitFor(() => {
-      expect(document.documentElement).toHaveClass("dark");
+      expect(document.documentElement).not.toHaveClass("no-transition");
     });
   });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,14 @@
   --foreground: #ededed;
 }
 
+/* 초기 로드 시 전환 애니메이션 비활성화 (FOUC 방지) */
+.no-transition,
+.no-transition *,
+.no-transition *::before,
+.no-transition *::after {
+  transition: none !important;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,14 @@ export default function RootLayout({
   const allPosts = postService.getAllPosts();
 
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem('theme');var t=s==='dark'||s==='light'?s:null;if(!t){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'}if(t==='dark'){document.documentElement.classList.add('dark')}document.documentElement.classList.add('no-transition')}catch(e){}})()`,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${sacramento.variable} antialiased min-h-screen flex flex-col`}
       >

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -9,20 +9,15 @@ export default function ThemeToggle() {
   useEffect(() => {
     setMounted(true);
 
-    // localStorage에서 저장된 테마 확인 (유효성 검증 포함)
-    const storedTheme = localStorage.getItem("theme");
-    const savedTheme = storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+    // 인라인 스크립트(layout.tsx <head>)가 이미 적용한 테마를 DOM에서 읽어 React state에 동기화
+    const isDark = document.documentElement.classList.contains("dark");
+    setTheme(isDark ? "dark" : "light");
+    updateFavicon(isDark ? "dark" : "light");
 
-    if (savedTheme) {
-      setTheme(savedTheme);
-      applyTheme(savedTheme);
-    } else {
-      // 시스템 다크모드 설정 감지
-      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      const systemTheme = prefersDark ? "dark" : "light";
-      setTheme(systemTheme);
-      applyTheme(systemTheme);
-    }
+    // 렌더링 완료 후 전환 애니메이션 활성화 (FOUC 방지용 no-transition 제거)
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove("no-transition");
+    });
 
     // 시스템 테마 변경 감지 리스너
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");


### PR DESCRIPTION
## Summary

- `<head>` 인라인 스크립트로 렌더링 전 테마 클래스(`.dark`)를 즉시 적용하여 FOUC 제거
- ThemeToggle 컴포넌트를 DOM 기반 테마 동기화로 변경 (중복 적용 제거)
- 초기 로드 시 `no-transition` 클래스로 전환 애니메이션 비활성화

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/app/layout.tsx` | `suppressHydrationWarning` + `<head>` 인라인 테마 스크립트 |
| `src/components/ThemeToggle.tsx` | DOM에서 테마 읽기 + no-transition 제거 |
| `src/app/globals.css` | `.no-transition` 클래스 추가 |
| `__tests__/components/ThemeToggle.test.tsx` | 새 동작에 맞게 테스트 업데이트 (8개) |

## How it works

```
Before: HTML → CSS(라이트) → JS hydration → useEffect → .dark 추가 (플리커!)
After:  HTML → <head> 스크립트 → .dark 즉시 적용 → CSS(다크) → 렌더링 (플리커 없음)
```

## Test plan

- [x] 전체 테스트 통과 (244/244)
- [x] 빌드 성공 (`npm run build`)
- [x] 다크모드 활성화 후 페이지 새로고침 - 플리커 없이 다크모드 유지
- [x] 다크모드 활성화 후 다른 페이지 이동 - 플리커 없이 다크모드 유지
- [x] 테마 토글 클릭 - 부드러운 전환 애니메이션 동작
- [x] 시크릿 모드 - 에러 없이 정상 동작

Closes #65