### PR TITLE
feat: 코드 블록 구문 강조(Syntax Highlighting) 개선 (#58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,10 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "reading-time": "^1.5.0",
+        "rehype-pretty-code": "^0.14.1",
         "rehype-slug": "^6.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "shiki": "^3.22.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2345,6 +2347,73 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.22.0.tgz",
+      "integrity": "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.22.0.tgz",
+      "integrity": "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.22.0.tgz",
+      "integrity": "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.22.0.tgz",
+      "integrity": "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.22.0.tgz",
+      "integrity": "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.22.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.22.0.tgz",
+      "integrity": "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
@@ -4901,7 +4970,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -6390,10 +6458,61 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-heading-rank": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
       "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -6425,6 +6544,29 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -6484,6 +6626,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -6520,6 +6679,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -10389,6 +10558,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
+      "integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz",
+      "integrity": "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10531,11 +10717,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+      "license": "ISC"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11011,6 +11202,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -11030,6 +11245,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-pretty-code": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.1.tgz",
+      "integrity": "sha512-IpG4OL0iYlbx78muVldsK86hdfNoht0z63AP7sekQNW2QOTmjxB7RbTO+rhIYNGRljgHxgVZoPwUl6bIC9SbjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "rehype-parse": "^9.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/rehype-recma": {
@@ -11492,6 +11742,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.22.0.tgz",
+      "integrity": "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.22.0",
+        "@shikijs/engine-javascript": "3.22.0",
+        "@shikijs/engine-oniguruma": "3.22.0",
+        "@shikijs/langs": "3.22.0",
+        "@shikijs/themes": "3.22.0",
+        "@shikijs/types": "3.22.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/side-channel": {
@@ -12924,6 +13190,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-matter": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
@@ -12973,6 +13253,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "reading-time": "^1.5.0",
+    "rehype-pretty-code": "^0.14.1",
     "rehype-slug": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "shiki": "^3.22.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,13 +2,25 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
+import rehypePrettyCode from "rehype-pretty-code";
+import type { Options as PrettyCodeOptions } from "rehype-pretty-code";
 import { postService } from "@/lib/container";
 import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";
 import TableOfContents from "@/components/TableOfContents";
 import RelatedPosts from "@/components/RelatedPosts";
+import CodeBlock from "@/components/CodeBlock";
 import { GlossaryProvider, GlossarySection, Term } from "@/components/glossary";
 import type { Metadata } from "next";
+
+const prettyCodeOptions: PrettyCodeOptions = {
+  theme: {
+    dark: "one-dark-pro",
+    light: "github-light",
+  },
+  keepBackground: false,
+  defaultLang: "plaintext",
+};
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -48,11 +60,11 @@ export default async function BlogPostPage({ params }: Props) {
   const mdxContent = (
     <MDXRemote
       source={post.content}
-      components={{ Term }}
+      components={{ Term, pre: CodeBlock }}
       options={{
         mdxOptions: {
           remarkPlugins: [remarkGfm],
-          rehypePlugins: [rehypeSlug],
+          rehypePlugins: [rehypeSlug, [rehypePrettyCode, prettyCodeOptions]],
         },
       }}
     />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -373,32 +373,173 @@ body::before {
   color: #94a3b8;
 }
 
-/* Code blocks - @layer를 사용하여 typography 플러그인 스타일 오버라이드 */
+/* ========================================
+   Code Blocks - Syntax Highlighting (Shiki)
+   ======================================== */
 @layer prose-overrides {
-  /* 라이트모드: 따뜻한 톤 */
+  /* --- 코드 블록 래퍼 --- */
+  .code-block-wrapper {
+    position: relative;
+    margin: 1.5rem 0;
+    text-align: left;
+  }
+
+  /* --- 코드 블록 헤더 (언어 라벨 + 복사 버튼) --- */
+  .code-block-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.375rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.025em;
+    text-transform: uppercase;
+    color: #92400e;
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    border-bottom: 1px solid rgba(253, 230, 138, 0.6);
+    border-radius: 0.75rem 0.75rem 0 0;
+    user-select: none;
+  }
+
+  .dark .code-block-header {
+    color: #94a3b8;
+    background: #1a2332;
+    border-color: #334155;
+    border-bottom-color: rgba(51, 65, 85, 0.6);
+  }
+
+  /* 헤더가 있는 경우 pre의 상단 border-radius 제거 */
+  .code-block-header + pre {
+    border-radius: 0 0 0.75rem 0.75rem !important;
+    border-top: none !important;
+  }
+
+  /* --- pre 태그 기본 스타일 --- */
   .prose pre {
     background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
     border: 1px solid #fde68a;
     border-radius: 0.75rem;
     padding: 1rem;
+    overflow-x: auto;
+    margin: 0;
+    text-align: left;
   }
 
   .prose pre code {
     background: transparent;
-    color: #92400e;
     padding: 0;
+    font-size: 0.875rem;
+    line-height: 1.7;
+    text-align: left;
   }
 
-  /* 다크모드 */
   .dark .prose pre {
     background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
     border-color: #334155;
   }
 
-  .dark .prose pre code {
-    color: #e2e8f0;
+  /* --- Shiki 듀얼 테마 토큰 색상 전환 --- */
+  .prose pre code span[style] {
+    color: var(--shiki-light) !important;
   }
 
+  .dark .prose pre code span[style] {
+    color: var(--shiki-dark) !important;
+  }
+
+  /* Shiki가 pre에 인라인 배경색을 넣는 것 방지 */
+  .prose pre[style] {
+    background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%) !important;
+  }
+
+  .dark .prose pre[style] {
+    background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%) !important;
+  }
+
+  /* --- 복사 버튼 (헤더 내) --- */
+  .code-copy-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border: none;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: #b45309;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .code-copy-button:hover {
+    background-color: rgba(251, 191, 36, 0.2);
+  }
+
+  .dark .code-copy-button {
+    color: #94a3b8;
+  }
+
+  .dark .code-copy-button:hover {
+    background-color: rgba(148, 163, 184, 0.15);
+  }
+
+  /* --- 플로팅 복사 버튼 (언어 라벨 없는 경우) --- */
+  .code-copy-button-floating {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+
+  .code-block-wrapper:hover .code-copy-button-floating {
+    opacity: 1;
+  }
+
+  /* --- 줄번호 (showLineNumbers 문법) --- */
+  .prose pre code[data-line-numbers] {
+    counter-reset: line;
+  }
+
+  .prose pre code[data-line-numbers] > [data-line]::before {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 1.5rem;
+    margin-right: 1rem;
+    text-align: right;
+    color: #d4a574;
+    opacity: 0.5;
+    user-select: none;
+  }
+
+  .dark .prose pre code[data-line-numbers] > [data-line]::before {
+    color: #64748b;
+  }
+
+  /* --- 라인 하이라이트 ({1,3-5} 문법) --- */
+  .prose pre code [data-highlighted-line] {
+    display: inline-block;
+    width: calc(100% + 2rem);
+    margin-left: -1rem;
+    padding-left: calc(1rem - 3px);
+    padding-right: 1rem;
+    background-color: rgba(251, 191, 36, 0.1);
+    border-left: 3px solid #f59e0b;
+  }
+
+  .dark .prose pre code [data-highlighted-line] {
+    background-color: rgba(96, 165, 250, 0.08);
+    border-left-color: #3b82f6;
+  }
+
+  /* --- 인라인 코드: Shiki 영향 방지 --- */
+  .prose :not(pre) > code {
+    color: inherit;
+  }
 }
 
 /* Blog post images */

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useRef, useState, useEffect } from "react";
+
+function CopyIcon() {
+  return (
+    <svg
+      className="icon-copy"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      className="icon-check"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+interface CodeBlockProps {
+  children: React.ReactNode;
+  "data-language"?: string;
+  [key: string]: unknown;
+}
+
+export default function CodeBlock({
+  children,
+  "data-language": language,
+  ...props
+}: CodeBlockProps) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    const code = preRef.current?.querySelector("code")?.textContent ?? "";
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // 클립보드 접근 불가 시 조용히 실패
+    }
+  };
+
+  return (
+    <div className="code-block-wrapper">
+      {language ? (
+        <div className="code-block-header">
+          <span>{language}</span>
+          <button
+            onClick={handleCopy}
+            className="code-copy-button"
+            aria-label="Copy code"
+          >
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={handleCopy}
+          className="code-copy-button code-copy-button-floating"
+          aria-label="Copy code"
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+        </button>
+      )}
+      <pre ref={preRef} {...props}>
+        {children}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/__tests__/CodeBlock.test.tsx
+++ b/src/components/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import CodeBlock from "../CodeBlock";
+
+// clipboard API mock
+const mockWriteText = jest.fn().mockResolvedValue(undefined);
+Object.assign(navigator, {
+  clipboard: { writeText: mockWriteText },
+});
+
+beforeEach(() => {
+  mockWriteText.mockClear();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("CodeBlock 컴포넌트", () => {
+  // ─────────────────────────────────────────────────────
+  // 1. 기본 렌더링
+  // ─────────────────────────────────────────────────────
+  describe("기본 렌더링", () => {
+    test("children이 pre 태그 내부에 렌더링된다", () => {
+      render(
+        <CodeBlock>
+          <code>console.log(&quot;hello&quot;)</code>
+        </CodeBlock>
+      );
+
+      const pre = screen.getByRole("code").closest("pre");
+      expect(pre).toBeInTheDocument();
+      expect(screen.getByText('console.log("hello")')).toBeInTheDocument();
+    });
+
+    test("data-language 속성이 있으면 언어 라벨이 표시된다", () => {
+      render(
+        <CodeBlock data-language="javascript">
+          <code>const x = 1;</code>
+        </CodeBlock>
+      );
+
+      expect(screen.getByText("javascript")).toBeInTheDocument();
+    });
+
+    test("data-language 속성이 없으면 언어 라벨이 표시되지 않는다", () => {
+      render(
+        <CodeBlock>
+          <code>plain text</code>
+        </CodeBlock>
+      );
+
+      // 헤더 영역 자체가 없어야 함
+      expect(
+        document.querySelector(".code-block-header")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 복사 버튼
+  // ─────────────────────────────────────────────────────
+  describe("복사 버튼", () => {
+    test("복사 버튼이 표시된다", () => {
+      render(
+        <CodeBlock data-language="js">
+          <code>const x = 1;</code>
+        </CodeBlock>
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Copy code" })
+      ).toBeInTheDocument();
+    });
+
+    test("복사 버튼 클릭 시 코드가 클립보드에 복사된다", async () => {
+      render(
+        <CodeBlock data-language="js">
+          <code>const x = 1;</code>
+        </CodeBlock>
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy code" });
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith("const x = 1;");
+    });
+
+    test("복사 성공 후 아이콘이 체크 표시로 변경된다", async () => {
+      render(
+        <CodeBlock data-language="js">
+          <code>const x = 1;</code>
+        </CodeBlock>
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy code" });
+
+      // 복사 전: CopyIcon 표시
+      expect(copyButton.querySelector(".icon-copy")).toBeInTheDocument();
+      expect(
+        copyButton.querySelector(".icon-check")
+      ).not.toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+      });
+
+      // 복사 후: CheckIcon 표시
+      expect(
+        copyButton.querySelector(".icon-copy")
+      ).not.toBeInTheDocument();
+      expect(copyButton.querySelector(".icon-check")).toBeInTheDocument();
+    });
+
+    test("복사 후 2초 뒤에 원래 아이콘으로 복원된다", async () => {
+      render(
+        <CodeBlock data-language="js">
+          <code>const x = 1;</code>
+        </CodeBlock>
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy code" });
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+      });
+
+      // 체크 아이콘 상태
+      expect(copyButton.querySelector(".icon-check")).toBeInTheDocument();
+
+      // 2초 후 원래 아이콘으로 복원
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(copyButton.querySelector(".icon-copy")).toBeInTheDocument();
+      expect(
+        copyButton.querySelector(".icon-check")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. 언어 라벨이 없는 경우 플로팅 복사 버튼
+  // ─────────────────────────────────────────────────────
+  describe("언어 라벨 없는 코드 블록", () => {
+    test("data-language가 없으면 플로팅 복사 버튼이 표시된다", () => {
+      render(
+        <CodeBlock>
+          <code>echo hello</code>
+        </CodeBlock>
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy code" });
+      expect(copyButton).toHaveClass("code-copy-button-floating");
+    });
+
+    test("플로팅 복사 버튼 클릭 시에도 코드가 복사된다", async () => {
+      render(
+        <CodeBlock>
+          <code>echo hello</code>
+        </CodeBlock>
+      );
+
+      const copyButton = screen.getByRole("button", { name: "Copy code" });
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+      });
+
+      expect(mockWriteText).toHaveBeenCalledWith("echo hello");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 4. props 전달
+  // ─────────────────────────────────────────────────────
+  describe("props 전달", () => {
+    test("추가 props가 pre 태그에 전달된다", () => {
+      render(
+        <CodeBlock data-language="ts" data-theme="one-dark-pro">
+          <code>type X = string;</code>
+        </CodeBlock>
+      );
+
+      const pre = document.querySelector("pre");
+      expect(pre).toHaveAttribute("data-theme", "one-dark-pro");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- rehype-pretty-code + Shiki 기반 빌드타임 구문 강조 적용
- 듀얼 테마: 라이트(github-light) / 다크(one-dark-pro)
- CodeBlock 컴포넌트: 언어 라벨 + 코드 복사 버튼
- 줄번호, 라인 하이라이트 지원
- 클라이언트 JS 번들 영향 없음 (빌드타임 처리)

## 변경된 파일
- `package.json` - rehype-pretty-code, shiki 의존성 추가
- `src/app/blog/[slug]/page.tsx` - rehype-pretty-code 플러그인 통합, CodeBlock 컴포넌트 연결
- `src/app/globals.css` - Shiki 듀얼 테마 CSS, 코드 블록 헤더/복사 버튼 스타일
- `src/components/CodeBlock.tsx` - 코드 블록 래퍼 컴포넌트 (언어 라벨, 복사 버튼)
- `src/components/__tests__/CodeBlock.test.tsx` - CodeBlock 단위 테스트 10개

## Test plan
- [x] 전체 테스트 통과 (271개)
- [x] 빌드 성공 (next build)
- [x] 코드 리뷰 완료 (CRITICAL/HIGH 0건)

Closes #58