### PR TITLE
시리즈 네비게이션 도입 및 관련글 로직 개선 (#62)

### DIFF
--- a/content/posts/javascript-closure.md
+++ b/content/posts/javascript-closure.md
@@ -5,6 +5,8 @@ description: "JavaScript 클로저의 동작 원리부터 실무 활용 패턴�
 category: "개발"
 subcategory: "JavaScript"
 tags: ["guide", "intermediate"]
+series: "javascript-core"
+seriesOrder: 1
 glossary:
   - id: "closure"
     term: "클로저(Closure)"

--- a/content/posts/javascript-this-binding.md
+++ b/content/posts/javascript-this-binding.md
@@ -5,6 +5,8 @@ description: "JavaScript에서 this가 결정되는 규칙을 호출 방식별�
 category: "개발"
 subcategory: "JavaScript"
 tags: ["guide", "intermediate"]
+series: "javascript-core"
+seriesOrder: 2
 ---
 
 <figure>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";
 import TableOfContents from "@/components/TableOfContents";
 import RelatedPosts from "@/components/RelatedPosts";
+import PostNavigation from "@/components/PostNavigation";
 import CodeBlock from "@/components/CodeBlock";
 import { GlossaryProvider, GlossarySection, Term } from "@/components/glossary";
 import type { Metadata } from "next";
@@ -55,6 +56,7 @@ export default async function BlogPostPage({ params }: Props) {
 
   const headings = extractHeadings(post.content);
   const relatedPosts = postService.getRelatedPosts(slug, 3);
+  const adjacentPosts = postService.getAdjacentPosts(slug);
   const glossary = post.glossary ?? [];
 
   const mdxContent = (
@@ -109,6 +111,10 @@ export default async function BlogPostPage({ params }: Props) {
             {glossary.length > 0 && <GlossarySection entries={glossary} />}
           </GlossaryProvider>
 
+          <PostNavigation
+            prev={adjacentPosts.prev}
+            next={adjacentPosts.next}
+          />
           <RelatedPosts posts={relatedPosts} />
         </article>
 

--- a/src/components/PostNavigation.tsx
+++ b/src/components/PostNavigation.tsx
@@ -1,0 +1,53 @@
+import type { PostMeta } from "@/types";
+
+interface PostNavigationProps {
+  prev: PostMeta | null;
+  next: PostMeta | null;
+}
+
+const PostNavigation: React.FC<PostNavigationProps> = ({ prev, next }) => {
+  if (!prev && !next) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="시리즈 네비게이션"
+      className="mt-10 grid grid-cols-2 gap-4 border-t border-zinc-200 pt-8 dark:border-zinc-700"
+    >
+      {prev ? (
+        <a
+          href={`/blog/${prev.slug}`}
+          className="group flex flex-col rounded-lg border border-zinc-200 p-4 transition-colors hover:border-amber-500 dark:border-zinc-700 dark:hover:border-amber-400"
+        >
+          <span className="mb-1 text-xs text-zinc-500 dark:text-zinc-400">
+            ← 이전 글
+          </span>
+          <span className="text-sm font-medium text-zinc-900 group-hover:text-amber-600 dark:text-zinc-100 dark:group-hover:text-amber-400">
+            {prev.title}
+          </span>
+        </a>
+      ) : (
+        <div />
+      )}
+
+      {next ? (
+        <a
+          href={`/blog/${next.slug}`}
+          className="group flex flex-col items-end rounded-lg border border-zinc-200 p-4 text-right transition-colors hover:border-amber-500 dark:border-zinc-700 dark:hover:border-amber-400"
+        >
+          <span className="mb-1 text-xs text-zinc-500 dark:text-zinc-400">
+            다음 글 →
+          </span>
+          <span className="text-sm font-medium text-zinc-900 group-hover:text-amber-600 dark:text-zinc-100 dark:group-hover:text-amber-400">
+            {next.title}
+          </span>
+        </a>
+      ) : (
+        <div />
+      )}
+    </nav>
+  );
+};
+
+export default PostNavigation;

--- a/src/lib/__tests__/related-posts.test.ts
+++ b/src/lib/__tests__/related-posts.test.ts
@@ -24,7 +24,7 @@ describe("calculateRelevanceScore", () => {
     tags: ["javascript", "react", "nextjs"],
   });
 
-  it("같은 subcategory일 때 +3점", () => {
+  it("같은 subcategory여도 subcategory 점수는 부여하지 않는다 (tag만 평가)", () => {
     const candidate = createPostMeta({
       slug: "candidate",
       category: "other",
@@ -32,10 +32,11 @@ describe("calculateRelevanceScore", () => {
       tags: [],
     });
 
-    expect(calculateRelevanceScore(currentPost, candidate)).toBe(3);
+    // subcategory 점수 제거됨: tag 공통 0개 = 0점
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(0);
   });
 
-  it("같은 category일 때 +2점", () => {
+  it("같은 category지만 subcategory 다르고 tag 없으면 0점", () => {
     const candidate = createPostMeta({
       slug: "candidate",
       category: "dev",
@@ -43,7 +44,7 @@ describe("calculateRelevanceScore", () => {
       tags: [],
     });
 
-    expect(calculateRelevanceScore(currentPost, candidate)).toBe(2);
+    expect(calculateRelevanceScore(currentPost, candidate)).toBe(0);
   });
 
   it("공통 tag 1개당 +1점", () => {
@@ -67,7 +68,7 @@ describe("calculateRelevanceScore", () => {
     expect(calculateRelevanceScore(currentPost, candidate)).toBe(0);
   });
 
-  it("복합 조건: 같은 category(+2) + 같은 subcategory(+3) + 공통 tag 2개(+2) = 7점", () => {
+  it("같은 subcategory + 공통 tag 2개 = 2점 (subcategory 점수 없음, tag만 평가)", () => {
     const candidate = createPostMeta({
       slug: "candidate",
       category: "dev",
@@ -75,52 +76,27 @@ describe("calculateRelevanceScore", () => {
       tags: ["javascript", "react", "typescript"],
     });
 
-    expect(calculateRelevanceScore(currentPost, candidate)).toBe(7);
-  });
-
-  it("currentPost의 subcategory가 undefined이면 subcategory 점수 0점", () => {
-    const noSubcategoryCurrent = createPostMeta({
-      slug: "current",
-      category: "dev",
-      subcategory: undefined,
-      tags: [],
-    });
-    const candidate = createPostMeta({
-      slug: "candidate",
-      category: "dev",
-      subcategory: "frontend",
-      tags: [],
-    });
-
-    expect(calculateRelevanceScore(noSubcategoryCurrent, candidate)).toBe(2);
-  });
-
-  it("candidate의 subcategory가 undefined이면 subcategory 점수 0점", () => {
-    const candidate = createPostMeta({
-      slug: "candidate",
-      category: "dev",
-      subcategory: undefined,
-      tags: [],
-    });
-
+    // subcategory 점수 제거됨: 공통 tag(javascript, react) = 2점
     expect(calculateRelevanceScore(currentPost, candidate)).toBe(2);
   });
 
-  it("양쪽 subcategory가 undefined이면 subcategory 매칭 안 함", () => {
-    const noSub1 = createPostMeta({
+  it("tag가 모두 동일하면 공통 tag 수만큼 점수를 부여한다", () => {
+    const post1 = createPostMeta({
       slug: "a",
-      category: "other",
-      subcategory: undefined,
-      tags: [],
+      tags: ["javascript", "react", "nextjs"],
     });
-    const noSub2 = createPostMeta({
+    const post2 = createPostMeta({
       slug: "b",
-      category: "other",
-      subcategory: undefined,
-      tags: [],
+      tags: ["javascript", "react", "nextjs"],
     });
 
-    // category만 일치 = 2점, undefined끼리 매칭하면 안 됨
-    expect(calculateRelevanceScore(noSub1, noSub2)).toBe(2);
+    expect(calculateRelevanceScore(post1, post2)).toBe(3);
+  });
+
+  it("양쪽 모두 tag가 비어있으면 0점", () => {
+    const post1 = createPostMeta({ slug: "a", tags: [] });
+    const post2 = createPostMeta({ slug: "b", tags: [] });
+
+    expect(calculateRelevanceScore(post1, post2)).toBe(0);
   });
 });

--- a/src/lib/related-posts.ts
+++ b/src/lib/related-posts.ts
@@ -1,39 +1,21 @@
 import type { PostMeta } from "@/types";
 
-const SUBCATEGORY_SCORE = 3;
-const CATEGORY_SCORE = 2;
 const TAG_SCORE = 1;
 
 /**
  * 두 포스트 간 관련도 점수를 계산한다.
  *
+ * 같은 subcategory 내에서만 호출되는 것을 전제로 한다.
  * 점수 기준:
- * - 같은 subcategory: +3
- * - 같은 category: +2
  * - 공통 tag 1개당: +1
  */
 export function calculateRelevanceScore(
   current: PostMeta,
   candidate: PostMeta
 ): number {
-  let score = 0;
-
-  if (
-    current.subcategory &&
-    candidate.subcategory &&
-    current.subcategory === candidate.subcategory
-  ) {
-    score += SUBCATEGORY_SCORE;
-  }
-
-  if (current.category === candidate.category) {
-    score += CATEGORY_SCORE;
-  }
-
   const commonTags = current.tags.filter((tag) =>
     candidate.tags.includes(tag)
   );
-  score += commonTags.length * TAG_SCORE;
 
-  return score;
+  return commonTags.length * TAG_SCORE;
 }

--- a/src/repositories/file-post.repository.ts
+++ b/src/repositories/file-post.repository.ts
@@ -124,6 +124,10 @@ export class FilePostRepository implements IPostRepository {
       subcategory: frontmatter.subcategory,
       tags: frontmatter.tags ?? [...POST_DEFAULTS.TAGS],
       readingTime: stats.text,
+      ...(frontmatter.series && { series: frontmatter.series }),
+      ...(frontmatter.seriesOrder != null && {
+        seriesOrder: frontmatter.seriesOrder,
+      }),
     };
   }
 

--- a/src/services/__tests__/post.service.test.ts
+++ b/src/services/__tests__/post.service.test.ts
@@ -23,6 +23,158 @@ function createPost(overrides: Partial<Post> = {}): Post {
   };
 }
 
+describe("PostService.getAdjacentPosts", () => {
+  let mockRepository: jest.Mocked<IPostRepository>;
+  let service: PostService;
+
+  beforeEach(() => {
+    mockRepository = {
+      findAll: jest.fn(),
+      findBySlug: jest.fn(),
+      findAllSlugs: jest.fn(),
+    };
+    service = new PostService(mockRepository);
+  });
+
+  it("같은 시리즈의 이전/다음 포스트를 반환한다", () => {
+    const currentPost = createPost({
+      slug: "js-this",
+      series: "javascript-core",
+      seriesOrder: 2,
+      category: "dev",
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-closure", series: "javascript-core", seriesOrder: 1, category: "dev" }),
+      createPostMeta({ slug: "js-this", series: "javascript-core", seriesOrder: 2, category: "dev" }),
+      createPostMeta({ slug: "js-prototype", series: "javascript-core", seriesOrder: 3, category: "dev" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getAdjacentPosts("js-this");
+
+    expect(result.prev?.slug).toBe("js-closure");
+    expect(result.next?.slug).toBe("js-prototype");
+  });
+
+  it("첫 번째 글이면 prev가 null이다", () => {
+    const currentPost = createPost({
+      slug: "js-closure",
+      series: "javascript-core",
+      seriesOrder: 1,
+      category: "dev",
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-closure", series: "javascript-core", seriesOrder: 1, category: "dev" }),
+      createPostMeta({ slug: "js-this", series: "javascript-core", seriesOrder: 2, category: "dev" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getAdjacentPosts("js-closure");
+
+    expect(result.prev).toBeNull();
+    expect(result.next?.slug).toBe("js-this");
+  });
+
+  it("마지막 글이면 next가 null이다", () => {
+    const currentPost = createPost({
+      slug: "js-this",
+      series: "javascript-core",
+      seriesOrder: 2,
+      category: "dev",
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-closure", series: "javascript-core", seriesOrder: 1, category: "dev" }),
+      createPostMeta({ slug: "js-this", series: "javascript-core", seriesOrder: 2, category: "dev" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getAdjacentPosts("js-this");
+
+    expect(result.prev?.slug).toBe("js-closure");
+    expect(result.next).toBeNull();
+  });
+
+  it("시리즈가 없는 포스트는 prev/next 모두 null이다", () => {
+    const currentPost = createPost({
+      slug: "random-post",
+      category: "dev",
+    });
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue([]);
+
+    const result = service.getAdjacentPosts("random-post");
+
+    expect(result.prev).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  it("존재하지 않는 slug일 때 prev/next 모두 null이다", () => {
+    mockRepository.findBySlug.mockReturnValue(null);
+
+    const result = service.getAdjacentPosts("nonexistent");
+
+    expect(result.prev).toBeNull();
+    expect(result.next).toBeNull();
+  });
+
+  it("다른 시리즈의 포스트는 포함하지 않는다", () => {
+    const currentPost = createPost({
+      slug: "js-this",
+      series: "javascript-core",
+      seriesOrder: 2,
+      category: "dev",
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-closure", series: "javascript-core", seriesOrder: 1, category: "dev" }),
+      createPostMeta({ slug: "js-this", series: "javascript-core", seriesOrder: 2, category: "dev" }),
+      createPostMeta({ slug: "react-intro", series: "react-basics", seriesOrder: 3, category: "dev" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getAdjacentPosts("js-this");
+
+    expect(result.prev?.slug).toBe("js-closure");
+    expect(result.next).toBeNull();
+  });
+
+  it("seriesOrder 순서대로 정렬하여 인접 포스트를 찾는다", () => {
+    const currentPost = createPost({
+      slug: "js-this",
+      series: "javascript-core",
+      seriesOrder: 2,
+      category: "dev",
+    });
+
+    // findAll 반환 순서가 seriesOrder와 다른 경우
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-prototype", series: "javascript-core", seriesOrder: 3, category: "dev" }),
+      createPostMeta({ slug: "js-closure", series: "javascript-core", seriesOrder: 1, category: "dev" }),
+      createPostMeta({ slug: "js-this", series: "javascript-core", seriesOrder: 2, category: "dev" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getAdjacentPosts("js-this");
+
+    expect(result.prev?.slug).toBe("js-closure");
+    expect(result.next?.slug).toBe("js-prototype");
+  });
+});
+
 describe("PostService.getRelatedPosts", () => {
   let mockRepository: jest.Mocked<IPostRepository>;
   let service: PostService;
@@ -36,7 +188,7 @@ describe("PostService.getRelatedPosts", () => {
     service = new PostService(mockRepository);
   });
 
-  it("관련 글이 있을 때 점수 내림차순으로 반환한다", () => {
+  it("같은 subcategory의 관련 글만 점수 내림차순으로 반환한다", () => {
     const currentPost = createPost({
       slug: "current",
       category: "dev",
@@ -46,9 +198,10 @@ describe("PostService.getRelatedPosts", () => {
 
     const allPosts: PostMeta[] = [
       createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react", "nextjs"] }),
-      createPostMeta({ slug: "high-score", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-03" }),  // sub(3) + cat(2) + tag(1) = 6
-      createPostMeta({ slug: "mid-score", category: "dev", subcategory: "backend", tags: ["nextjs"], date: "2025-01-02" }),   // cat(2) + tag(1) = 3
-      createPostMeta({ slug: "low-score", category: "life", tags: ["react"], date: "2025-01-01" }),                            // tag(1) = 1
+      createPostMeta({ slug: "high-score", category: "dev", subcategory: "frontend", tags: ["react", "nextjs"], date: "2025-01-03" }),  // tag(2) = 2
+      createPostMeta({ slug: "mid-score", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-02" }),              // tag(1) = 1
+      createPostMeta({ slug: "diff-sub", category: "dev", subcategory: "backend", tags: ["react"], date: "2025-01-01" }),                // 다른 subcategory → 제외
+      createPostMeta({ slug: "diff-cat", category: "life", tags: ["react"], date: "2025-01-01" }),                                        // 다른 카테고리 → 제외
     ];
 
     mockRepository.findBySlug.mockReturnValue(currentPost);
@@ -56,22 +209,23 @@ describe("PostService.getRelatedPosts", () => {
 
     const result = service.getRelatedPosts("current", 3);
 
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(2);
     expect(result[0].slug).toBe("high-score");
     expect(result[1].slug).toBe("mid-score");
-    expect(result[2].slug).toBe("low-score");
+    expect(result.every((p) => p.subcategory === "frontend")).toBe(true);
   });
 
   it("현재 글은 결과에서 제외된다", () => {
     const currentPost = createPost({
       slug: "current",
       category: "dev",
+      subcategory: "frontend",
       tags: ["react"],
     });
 
     const allPosts: PostMeta[] = [
-      createPostMeta({ slug: "current", category: "dev", tags: ["react"] }),
-      createPostMeta({ slug: "other", category: "dev", tags: ["react"] }),
+      createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react"] }),
+      createPostMeta({ slug: "other", category: "dev", subcategory: "frontend", tags: ["react"] }),
     ];
 
     mockRepository.findBySlug.mockReturnValue(currentPost);
@@ -87,14 +241,15 @@ describe("PostService.getRelatedPosts", () => {
     const currentPost = createPost({
       slug: "current",
       category: "dev",
+      subcategory: "frontend",
       tags: ["react"],
     });
 
     const allPosts: PostMeta[] = [
-      createPostMeta({ slug: "current", category: "dev", tags: ["react"] }),
-      createPostMeta({ slug: "a", category: "dev", tags: ["react"], date: "2025-01-03" }),
-      createPostMeta({ slug: "b", category: "dev", tags: ["react"], date: "2025-01-02" }),
-      createPostMeta({ slug: "c", category: "dev", tags: ["react"], date: "2025-01-01" }),
+      createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react"] }),
+      createPostMeta({ slug: "a", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-03" }),
+      createPostMeta({ slug: "b", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-02" }),
+      createPostMeta({ slug: "c", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-01" }),
     ];
 
     mockRepository.findBySlug.mockReturnValue(currentPost);
@@ -109,13 +264,14 @@ describe("PostService.getRelatedPosts", () => {
     const currentPost = createPost({
       slug: "current",
       category: "dev",
+      subcategory: "frontend",
       tags: ["react"],
     });
 
     const allPosts: PostMeta[] = [
-      createPostMeta({ slug: "current", category: "dev", tags: ["react"] }),
-      createPostMeta({ slug: "older", category: "dev", tags: ["react"], date: "2025-01-01" }),
-      createPostMeta({ slug: "newer", category: "dev", tags: ["react"], date: "2025-06-01" }),
+      createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react"] }),
+      createPostMeta({ slug: "older", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-01-01" }),
+      createPostMeta({ slug: "newer", category: "dev", subcategory: "frontend", tags: ["react"], date: "2025-06-01" }),
     ];
 
     mockRepository.findBySlug.mockReturnValue(currentPost);
@@ -127,7 +283,7 @@ describe("PostService.getRelatedPosts", () => {
     expect(result[1].slug).toBe("older");
   });
 
-  it("관련 글이 없을 때(점수 0점만) 최신 글 fallback", () => {
+  it("같은 subcategory에 관련 tag 없으면 같은 subcategory 최신 글 fallback", () => {
     const currentPost = createPost({
       slug: "current",
       category: "dev",
@@ -137,8 +293,9 @@ describe("PostService.getRelatedPosts", () => {
 
     const allPosts: PostMeta[] = [
       createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react"] }),
-      createPostMeta({ slug: "unrelated-new", category: "life", tags: ["travel"], date: "2025-06-01" }),
-      createPostMeta({ slug: "unrelated-old", category: "life", tags: ["food"], date: "2025-01-01" }),
+      createPostMeta({ slug: "fe-new", category: "dev", subcategory: "frontend", tags: ["svelte"], date: "2025-06-01" }),
+      createPostMeta({ slug: "fe-old", category: "dev", subcategory: "frontend", tags: ["angular"], date: "2025-01-01" }),
+      createPostMeta({ slug: "be-post", category: "dev", subcategory: "backend", tags: ["react"], date: "2025-07-01" }),
     ];
 
     mockRepository.findBySlug.mockReturnValue(currentPost);
@@ -146,10 +303,33 @@ describe("PostService.getRelatedPosts", () => {
 
     const result = service.getRelatedPosts("current", 3);
 
-    // fallback: 최신 글 순서
+    // fallback: 같은 subcategory 최신 글 순서 (backend 제외)
     expect(result).toHaveLength(2);
-    expect(result[0].slug).toBe("unrelated-new");
-    expect(result[1].slug).toBe("unrelated-old");
+    expect(result[0].slug).toBe("fe-new");
+    expect(result[1].slug).toBe("fe-old");
+    expect(result.every((p) => p.subcategory === "frontend")).toBe(true);
+  });
+
+  it("같은 subcategory 글이 없으면 빈 배열 반환", () => {
+    const currentPost = createPost({
+      slug: "current",
+      category: "dev",
+      subcategory: "frontend",
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "current", category: "dev", subcategory: "frontend", tags: ["react"] }),
+      createPostMeta({ slug: "be-1", category: "dev", subcategory: "backend", tags: ["react"], date: "2025-06-01" }),
+      createPostMeta({ slug: "life-1", category: "life", tags: ["travel"], date: "2025-01-01" }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("current", 3);
+
+    expect(result).toEqual([]);
   });
 
   it("존재하지 않는 slug일 때 빈 배열 반환", () => {
@@ -164,17 +344,39 @@ describe("PostService.getRelatedPosts", () => {
     const currentPost = createPost({
       slug: "only-post",
       category: "dev",
+      subcategory: "frontend",
       tags: ["react"],
     });
 
     const allPosts: PostMeta[] = [
-      createPostMeta({ slug: "only-post", category: "dev", tags: ["react"] }),
+      createPostMeta({ slug: "only-post", category: "dev", subcategory: "frontend", tags: ["react"] }),
     ];
 
     mockRepository.findBySlug.mockReturnValue(currentPost);
     mockRepository.findAll.mockReturnValue(allPosts);
 
     const result = service.getRelatedPosts("only-post", 3);
+
+    expect(result).toEqual([]);
+  });
+
+  it("currentPost에 subcategory가 없으면 빈 배열 반환", () => {
+    const currentPost = createPost({
+      slug: "no-sub",
+      category: "dev",
+      subcategory: undefined,
+      tags: ["react"],
+    });
+
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "no-sub", category: "dev", tags: ["react"] }),
+      createPostMeta({ slug: "other", category: "dev", subcategory: "frontend", tags: ["react"] }),
+    ];
+
+    mockRepository.findBySlug.mockReturnValue(currentPost);
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getRelatedPosts("no-sub", 3);
 
     expect(result).toEqual([]);
   });

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -10,6 +10,8 @@ export interface PostMeta {
   subcategory?: string;
   tags: string[];
   readingTime: string;
+  series?: string;
+  seriesOrder?: number;
 }
 
 /**
@@ -30,4 +32,6 @@ export interface PostFrontmatter {
   category?: string;
   subcategory?: string;
   tags?: string[];
+  series?: string;
+  seriesOrder?: number;
 }


### PR DESCRIPTION
## 개요
시리즈 내 이전/다음 글 네비게이션을 도입하고, 관련글 추천 로직을 category 기반에서 subcategory 기반으로 변경하여 추천 정확도를 개선했습니다.

---

## 주요 변경 사항

### 1. 시리즈 네비게이션
- `PostMeta`/`PostFrontmatter` 타입에 `series`, `seriesOrder` 필드 추가
- `getAdjacentPosts()` 메서드로 같은 시리즈 내 이전/다음 글 조회
- `PostNavigation` 컴포넌트 신규 생성 (이전 글 ← / → 다음 글)
- javascript-core 시리즈 설정 (클로저 #1, this 바인딩 #2)

### 2. 관련글 로직 개선
- 필터 기준: `category` → `subcategory`로 변경
- `CATEGORY_SCORE`(+2), `SUBCATEGORY_SCORE`(+3) 제거
- 점수 계산: 공통 tag 개수만으로 단순화
- subcategory 없는 포스트는 관련글 빈 배열 반환 (정직한 빈 결과)

### 변경 이유
같은 "개발" 카테고리 안에 JavaScript, 웹, Next.js 글이 섞여 있어서 Next.js 글을 읽는데 JavaScript 클로저 글이 "관련글"로 표시되는 부자연스러운 현상이 있었습니다. subcategory 기준으로 변경하여 실제로 관련 있는 글만 추천하도록 개선했습니다.

---

## 변경된 파일 (10개)

### 신규
- `src/components/PostNavigation.tsx` - 시리즈 네비게이션 컴포넌트

### 수정
- `src/types/post.ts` - series, seriesOrder 필드 추가
- `src/repositories/file-post.repository.ts` - series 필드 파싱
- `src/services/post.service.ts` - getAdjacentPosts 추가, getRelatedPosts 필터 변경
- `src/lib/related-posts.ts` - SUBCATEGORY_SCORE/CATEGORY_SCORE 제거
- `src/app/blog/[slug]/page.tsx` - PostNavigation 통합
- `content/posts/javascript-closure.md` - series frontmatter 추가
- `content/posts/javascript-this-binding.md` - series frontmatter 추가
- `src/services/__tests__/post.service.test.ts` - 테스트 추가/수정
- `src/lib/__tests__/related-posts.test.ts` - 테스트 수정

---

## 코드 리뷰 결과

### 보안 리뷰: 0 issues
- 빌드 타임 정적 코드로 사용자 입력 처리 없음
- OWASP Top 10 전 항목 안전

### 품질 리뷰: 0 issues
- 모든 함수 50줄 이하
- 중첩 깊이 3레벨 이하
- TODO/FIXME 없음
- 하드코딩된 비밀정보 없음

---

## 테스트
- 전체 262개 테스트 통과
- getAdjacentPosts 7개 테스트 추가
- getRelatedPosts subcategory 기반 테스트 8개 (신규 2개 포함)
- calculateRelevanceScore tag 전용 테스트 7개

Closes #62