### PR TITLE
feat: Scroll to Top 버튼 및 뒤로가기 버튼 추가 (#79, #80)

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -11,6 +11,7 @@ import TableOfContents from "@/components/TableOfContents";
 import RelatedPosts from "@/components/RelatedPosts";
 import PostNavigation from "@/components/PostNavigation";
 import CodeBlock from "@/components/CodeBlock";
+import BackButton from "@/components/BackButton";
 import { GlossaryProvider, GlossarySection, Term } from "@/components/glossary";
 import type { Metadata } from "next";
 
@@ -77,6 +78,7 @@ export default async function BlogPostPage({ params }: Props) {
       <div className="flex gap-8">
         {/* 본문 영역 */}
         <article className="min-w-0 flex-1">
+          <BackButton />
           <header className="mb-12">
             <time
               dateTime={post.date}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import ImageLightbox from "@/components/ImageLightbox";
 import SearchModal from "@/components/SearchModal";
 import SearchButton from "@/components/SearchButton";
+import ScrollToTop from "@/components/ScrollToTop";
 import { postService } from "@/lib/container";
 import "./globals.css";
 
@@ -90,6 +91,7 @@ export default function RootLayout({
         <main className="flex-1">{children}</main>
 
         <ImageLightbox />
+        <ScrollToTop />
         <SearchModal posts={allPosts} />
 
         <footer className="border-t border-zinc-200 py-8 dark:border-zinc-800">

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -6,7 +6,12 @@ export default function BackButton() {
   const router = useRouter();
 
   const handleClick = () => {
-    if (window.history.length > 1) {
+    const referrer = document.referrer;
+    const isSameOrigin =
+      referrer !== "" &&
+      new URL(referrer).origin === window.location.origin;
+
+    if (isSameOrigin) {
       router.back();
     } else {
       router.push("/blog");

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/blog");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label="뒤로 가기"
+      onClick={handleClick}
+      className="mb-6 flex items-center gap-1 text-sm text-zinc-500 transition-colors duration-200 hover:text-amber-700 dark:text-zinc-400 dark:hover:text-zinc-100"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="h-4 w-4"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z"
+          clipRule="evenodd"
+        />
+      </svg>
+      목록으로
+    </button>
+  );
+}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -10,7 +10,7 @@ import { useScrollPosition } from "@/hooks/useScrollPosition";
  * - SSR hydration mismatch 방지를 위해 mounted 상태 관리
  * - 클릭 시 smooth scroll로 최상단 이동
  * - 라이트/다크 모드 대응
- * - 접근성: aria-label, focus-visible 스타일
+ * - 접근성: aria-label, aria-hidden, tabIndex, focus-visible 스타일
  */
 export default function ScrollToTop() {
   const [mounted, setMounted] = useState(false);
@@ -32,6 +32,8 @@ export default function ScrollToTop() {
       type="button"
       onClick={handleClick}
       aria-label="맨 위로 이동"
+      aria-hidden={!isScrolled}
+      tabIndex={isScrolled ? 0 : -1}
       className={`fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-40
         w-10 h-10 sm:w-12 sm:h-12
         flex items-center justify-center

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useScrollPosition } from "@/hooks/useScrollPosition";
+
+/**
+ * 페이지 최상단으로 스크롤하는 플로팅 버튼 컴포넌트.
+ *
+ * - 스크롤 위치가 300px 이상이면 표시
+ * - SSR hydration mismatch 방지를 위해 mounted 상태 관리
+ * - 클릭 시 smooth scroll로 최상단 이동
+ * - 라이트/다크 모드 대응
+ * - 접근성: aria-label, focus-visible 스타일
+ */
+export default function ScrollToTop() {
+  const [mounted, setMounted] = useState(false);
+  const isScrolled = useScrollPosition(300);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  function handleClick() {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  // SSR hydration mismatch 방지: 서버에서는 렌더링하지 않음
+  if (!mounted) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="맨 위로 이동"
+      className={`fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-40
+        w-10 h-10 sm:w-12 sm:h-12
+        flex items-center justify-center
+        rounded-full
+        bg-amber-500/90 hover:bg-amber-600
+        dark:bg-zinc-700/90 dark:hover:bg-zinc-600
+        text-white dark:text-zinc-100
+        shadow-lg shadow-amber-500/25 dark:shadow-black/25
+        transition-all duration-300 ease-in-out
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2
+        dark:focus-visible:ring-zinc-400 dark:focus-visible:ring-offset-zinc-900
+        cursor-pointer
+        ${
+          isScrolled
+            ? "opacity-100 translate-y-0 pointer-events-auto"
+            : "opacity-0 translate-y-4 pointer-events-none"
+        }`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="w-5 h-5 sm:w-6 sm:h-6"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M9.47 6.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 1 1-1.06 1.06L10 8.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06l4.25-4.25Z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/__tests__/BackButton.test.tsx
+++ b/src/components/__tests__/BackButton.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import BackButton from "../BackButton";
+
+/**
+ * BackButton 컴포넌트 테스트.
+ *
+ * - "목록으로" 텍스트와 좌측 화살표 SVG 아이콘을 표시
+ * - history.length > 1 이면 router.back() 호출 (이전 페이지로 복귀)
+ * - history.length <= 1 이면 router.push("/blog") 호출 (직접 접근 시 목록으로)
+ * - 접근성: aria-label="뒤로 가기"
+ * - 스타일: text-sm, mb-6, transition-colors, duration-200
+ */
+
+const mockBack = jest.fn();
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    back: mockBack,
+    push: mockPush,
+  }),
+}));
+
+describe("BackButton", () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockPush.mockClear();
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 1. 렌더링
+  // ─────────────────────────────────────────────────────
+  describe("렌더링", () => {
+    test('"목록으로" 텍스트가 표시된다', () => {
+      render(<BackButton />);
+
+      expect(screen.getByText("목록으로")).toBeInTheDocument();
+    });
+
+    test("버튼 요소로 렌더링된다", () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      expect(button).toBeInTheDocument();
+    });
+
+    test("좌측 화살표 SVG 아이콘이 포함된다", () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      const svg = button.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 클릭 동작
+  // ─────────────────────────────────────────────────────
+  describe("클릭 동작", () => {
+    test("history.length > 1일 때 클릭 시 router.back()이 호출된다", () => {
+      Object.defineProperty(window.history, "length", {
+        value: 3,
+        writable: true,
+        configurable: true,
+      });
+
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      fireEvent.click(button);
+
+      expect(mockBack).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    test("history.length <= 1일 때 클릭 시 router.push('/blog')가 호출된다", () => {
+      Object.defineProperty(window.history, "length", {
+        value: 1,
+        writable: true,
+        configurable: true,
+      });
+
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      fireEvent.click(button);
+
+      expect(mockPush).toHaveBeenCalledWith("/blog");
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      expect(mockBack).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. 접근성
+  // ─────────────────────────────────────────────────────
+  describe("접근성", () => {
+    test('aria-label이 "뒤로 가기"로 설정된다', () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      expect(button).toHaveAttribute("aria-label", "뒤로 가기");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 4. 스타일
+  // ─────────────────────────────────────────────────────
+  describe("스타일", () => {
+    test("text-sm 클래스가 적용된다", () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      expect(button).toHaveClass("text-sm");
+    });
+
+    test("mb-6 클래스가 적용된다", () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      expect(button).toHaveClass("mb-6");
+    });
+
+    test("transition-colors와 duration-200 클래스가 적용된다", () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole("button", { name: "뒤로 가기" });
+      expect(button).toHaveClass("transition-colors");
+      expect(button).toHaveClass("duration-200");
+    });
+  });
+});

--- a/src/components/__tests__/ScrollToTop.test.tsx
+++ b/src/components/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,266 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import ScrollToTop from "../ScrollToTop";
+
+/**
+ * ScrollToTop 컴포넌트 테스트.
+ *
+ * - useScrollPosition 훅을 사용하여 스크롤 위치에 따라 버튼 표시/숨김
+ * - SSR hydration mismatch 방지를 위한 mounted 상태 관리
+ * - 클릭 시 window.scrollTo({ top: 0, behavior: 'smooth' }) 호출
+ * - 접근성: aria-label, focus-visible 스타일
+ */
+
+// window.scrollTo 모킹
+const scrollToMock = jest.fn();
+Object.defineProperty(window, "scrollTo", {
+  value: scrollToMock,
+  writable: true,
+});
+
+describe("ScrollToTop", () => {
+  beforeEach(() => {
+    scrollToMock.mockClear();
+    Object.defineProperty(window, "scrollY", { value: 0, writable: true });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 1. SSR hydration 안전성
+  // ─────────────────────────────────────────────────────
+  describe("SSR hydration 안전성", () => {
+    test("마운트 후 스크롤 위치가 0이면 버튼이 숨겨진 상태로 렌더링된다", () => {
+      // jsdom에서 useEffect는 render 시 동기 실행되므로 mounted=true가 즉시 적용됨.
+      // 실제 SSR에서는 useEffect가 실행되지 않아 mounted=false → null 반환.
+      // 여기서는 마운트 후 scrollY=0일 때 버튼이 숨겨진(opacity-0, pointer-events-none) 상태인지 검증.
+      render(<ScrollToTop />);
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toHaveClass("opacity-0");
+      expect(button).toHaveClass("pointer-events-none");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 버튼 표시/숨김
+  // ─────────────────────────────────────────────────────
+  describe("버튼 표시/숨김", () => {
+    test("스크롤 위치가 threshold 미만이면 버튼이 숨겨진다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 100,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      // 버튼이 없거나 숨겨진 상태
+      const button = screen.queryByRole("button", { name: "맨 위로 이동" });
+      if (button) {
+        // 버튼이 DOM에 있더라도 opacity-0으로 숨겨진 상태
+        expect(button).toHaveClass("opacity-0");
+      }
+    });
+
+    test("스크롤 위치가 threshold 이상이면 버튼이 표시된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 400,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveClass("opacity-100");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. 클릭 동작
+  // ─────────────────────────────────────────────────────
+  describe("클릭 동작", () => {
+    test("버튼 클릭 시 window.scrollTo가 호출된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+
+      act(() => {
+        fireEvent.click(button);
+      });
+
+      expect(scrollToMock).toHaveBeenCalledWith({
+        top: 0,
+        behavior: "smooth",
+      });
+    });
+
+    test("버튼 클릭 시 scrollTo가 정확히 1회 호출된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+
+      act(() => {
+        fireEvent.click(button);
+      });
+
+      expect(scrollToMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 4. 접근성
+  // ─────────────────────────────────────────────────────
+  describe("접근성", () => {
+    test('aria-label이 "맨 위로 이동"으로 설정된다', () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toHaveAttribute("aria-label", "맨 위로 이동");
+    });
+
+    test("위쪽 화살표 SVG 아이콘이 포함된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      const svg = button.querySelector("svg");
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 5. 스타일 및 위치
+  // ─────────────────────────────────────────────────────
+  describe("스타일 및 위치", () => {
+    test("fixed 포지션으로 렌더링된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toHaveClass("fixed");
+    });
+
+    test("z-40으로 설정된다 (header z-50보다 낮게)", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toHaveClass("z-40");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 6. 애니메이션 전환
+  // ─────────────────────────────────────────────────────
+  describe("애니메이션 전환", () => {
+    test("표시 시 opacity-100과 translate-y-0 클래스가 적용된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toHaveClass("opacity-100");
+      expect(button).toHaveClass("translate-y-0");
+    });
+
+    test("숨김 시 opacity-0과 translate-y-4 클래스가 적용된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 0,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.queryByRole("button", { name: "맨 위로 이동" });
+      if (button) {
+        expect(button).toHaveClass("opacity-0");
+        expect(button).toHaveClass("translate-y-4");
+      }
+    });
+
+    test("duration-300 전환 클래스가 적용된다", () => {
+      Object.defineProperty(window, "scrollY", {
+        value: 500,
+        writable: true,
+      });
+
+      render(<ScrollToTop />);
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      const button = screen.getByRole("button", { name: "맨 위로 이동" });
+      expect(button).toHaveClass("duration-300");
+    });
+  });
+});

--- a/src/hooks/__tests__/useScrollPosition.test.ts
+++ b/src/hooks/__tests__/useScrollPosition.test.ts
@@ -1,0 +1,181 @@
+import { renderHook, act } from "@testing-library/react";
+import { useScrollPosition } from "../useScrollPosition";
+
+describe("useScrollPosition", () => {
+  // ─────────────────────────────────────────────────────
+  // 1. 초기 상태
+  // ─────────────────────────────────────────────────────
+  describe("초기 상태", () => {
+    test("scrollY가 0이면 false를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 0, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      expect(result.current).toBe(false);
+    });
+
+    test("초기 scrollY가 threshold 이상이면 true를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 500, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      // 초기 렌더 시 scroll 이벤트가 발생하지 않으므로 false
+      // scroll 이벤트가 발생해야 상태 반영
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 기본 threshold (300px)
+  // ─────────────────────────────────────────────────────
+  describe("기본 threshold (300px)", () => {
+    test("scrollY가 300 미만이면 false를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 299, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(false);
+    });
+
+    test("scrollY가 정확히 300이면 true를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 300, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    test("scrollY가 300 이상이면 true를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 500, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. 커스텀 threshold
+  // ─────────────────────────────────────────────────────
+  describe("커스텀 threshold", () => {
+    test("threshold 100px로 설정하면 scrollY 100에서 true를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 100, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition(100));
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    test("threshold 100px로 설정하면 scrollY 99에서 false를 반환한다", () => {
+      Object.defineProperty(window, "scrollY", { value: 99, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition(100));
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(false);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 4. 스크롤 위치 변경 반응
+  // ─────────────────────────────────────────────────────
+  describe("스크롤 위치 변경 반응", () => {
+    test("스크롤 다운하면 false에서 true로 변경된다", () => {
+      Object.defineProperty(window, "scrollY", { value: 0, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      expect(result.current).toBe(false);
+
+      // 스크롤 다운
+      Object.defineProperty(window, "scrollY", { value: 400, writable: true });
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    test("스크롤 업하면 true에서 false로 변경된다", () => {
+      Object.defineProperty(window, "scrollY", { value: 400, writable: true });
+
+      const { result } = renderHook(() => useScrollPosition());
+
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(true);
+
+      // 스크롤 업
+      Object.defineProperty(window, "scrollY", { value: 100, writable: true });
+      act(() => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+
+      expect(result.current).toBe(false);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 5. 이벤트 리스너 등록 옵션
+  // ─────────────────────────────────────────────────────
+  describe("이벤트 리스너 등록", () => {
+    test("scroll 이벤트 리스너가 passive: true로 등록된다", () => {
+      const addEventListenerSpy = jest.spyOn(window, "addEventListener");
+
+      renderHook(() => useScrollPosition());
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+        { passive: true }
+      );
+
+      addEventListenerSpy.mockRestore();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 6. 클린업
+  // ─────────────────────────────────────────────────────
+  describe("클린업", () => {
+    test("언마운트 시 scroll 이벤트 리스너가 제거된다", () => {
+      const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+
+      const { unmount } = renderHook(() => useScrollPosition());
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function)
+      );
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+});

--- a/src/hooks/useScrollPosition.ts
+++ b/src/hooks/useScrollPosition.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+/**
+ * 스크롤 위치를 감지하는 커스텀 훅.
+ *
+ * - window.scrollY가 threshold 이상이면 true 반환
+ * - scroll 이벤트 리스너를 passive: true로 등록 (스크롤 성능 보장)
+ * - 언마운트 시 리스너 정리
+ *
+ * @param threshold 스크롤 위치 임계값 (기본값: 300px)
+ * @returns threshold 이상 스크롤했는지 여부
+ */
+export function useScrollPosition(threshold = 300): boolean {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    function handleScroll() {
+      setIsScrolled(window.scrollY >= threshold);
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [threshold]);
+
+  return isScrolled;
+}


### PR DESCRIPTION
## Summary
- Scroll to Top 버튼 추가: 스크롤 300px 이상 시 우하단 플로팅 버튼 표시, 클릭 시 부드러운 최상단 이동 (#79)
- 블로그 포스트 뒤로가기 버튼 추가: 포스트 상단에 "← 목록으로" 버튼, referrer 기반 네비게이션 (#80)
- 다크/라이트 모드, 모바일/데스크탑 반응형, 접근성(aria-hidden, tabIndex, focus-visible) 대응

## Changes

### #79 Scroll to Top 버튼
- `src/hooks/useScrollPosition.ts` - 스크롤 위치 감지 커스텀 훅
- `src/components/ScrollToTop.tsx` - 플로팅 버튼 (SSR hydration 안전)
- `src/app/layout.tsx` - 전역 레이아웃에 통합

### #80 뒤로가기 버튼
- `src/components/BackButton.tsx` - document.referrer 기반 뒤로가기
- `src/app/blog/[slug]/page.tsx` - 포스트 페이지에 통합

## Test plan
- [x] useScrollPosition 훅 테스트 (11건)
- [x] ScrollToTop 컴포넌트 테스트 (12건)
- [x] BackButton 컴포넌트 테스트 (9건)
- [x] 전체 테스트 297건 통과
- [x] 프로덕션 빌드 성공

Closes #79, Closes #80