### PR TITLE
feat: 블로그 카테고리 필터링 사이드바 트리 구조 도입 (#72)

### DIFF
--- a/__tests__/components/BlogFilter.test.tsx
+++ b/__tests__/components/BlogFilter.test.tsx
@@ -1,11 +1,18 @@
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import BlogFilter from "@/components/BlogFilter";
 import type { PostMeta } from "@/types";
 
 /**
  * BlogFilter 컴포넌트 테스트
  *
- * React Testing Library를 사용하여 UI 동작을 테스트합니다.
+ * 카테고리 필터링은 useCategoryFilter 훅과 CategoryTree 컴포넌트에서 처리.
+ * BlogFilter는 검색 + 포스트 목록 렌더링만 담당.
  */
 
 // Next.js Link 컴포넌트 모킹
@@ -54,176 +61,68 @@ describe("BlogFilter", () => {
     },
   ];
 
-  describe("카테고리 버튼 렌더링", () => {
-    it("should render '전체' button", () => {
-      render(<BlogFilter posts={mockPosts} />);
+  const defaultProps = {
+    posts: mockPosts,
+    selectedCategory: null as string | null,
+    selectedSubcategory: null as string | null,
+  };
 
-      expect(screen.getByRole("button", { name: "전체" })).toBeInTheDocument();
-    });
-
-    it("should render all unique category buttons", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      expect(screen.getByRole("button", { name: "개발" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "일상" })).toBeInTheDocument();
-    });
-
-    it("should render all posts initially", () => {
-      render(<BlogFilter posts={mockPosts} />);
+  describe("포스트 목록 렌더링", () => {
+    it("should render all posts", () => {
+      render(<BlogFilter {...defaultProps} />);
 
       expect(screen.getByText("React 시작하기")).toBeInTheDocument();
       expect(screen.getByText("TypeScript 타입 시스템")).toBeInTheDocument();
       expect(screen.getByText("제주도 여행")).toBeInTheDocument();
     });
-  });
 
-  describe("카테고리 클릭 시 필터링 동작", () => {
-    it("should filter posts when category is clicked", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      const devButton = screen.getByRole("button", { name: "개발" });
-      fireEvent.click(devButton);
-
-      expect(screen.getByText("React 시작하기")).toBeInTheDocument();
-      expect(screen.getByText("TypeScript 타입 시스템")).toBeInTheDocument();
-      expect(screen.queryByText("제주도 여행")).not.toBeInTheDocument();
-    });
-
-    it("should show all posts when 전체 is clicked", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      // 먼저 카테고리 선택
-      fireEvent.click(screen.getByRole("button", { name: "개발" }));
-      expect(screen.queryByText("제주도 여행")).not.toBeInTheDocument();
-
-      // 전체 클릭
-      fireEvent.click(screen.getByRole("button", { name: "전체" }));
-      expect(screen.getByText("React 시작하기")).toBeInTheDocument();
-      expect(screen.getByText("TypeScript 타입 시스템")).toBeInTheDocument();
-      expect(screen.getByText("제주도 여행")).toBeInTheDocument();
-    });
-
-    it("should filter to single category posts", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "일상" }));
-
-      expect(screen.queryByText("React 시작하기")).not.toBeInTheDocument();
-      expect(screen.queryByText("TypeScript 타입 시스템")).not.toBeInTheDocument();
-      expect(screen.getByText("제주도 여행")).toBeInTheDocument();
-    });
-  });
-
-  describe("서브카테고리 표시/숨김", () => {
-    it("should show subcategory buttons when category with subcategories is selected", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "개발" }));
-
-      expect(screen.getByRole("button", { name: "React" })).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: "TypeScript" })
-      ).toBeInTheDocument();
-    });
-
-    it("should hide subcategory buttons when category without subcategories is selected", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "일상" }));
-
-      expect(
-        screen.queryByRole("button", { name: "React" })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: "TypeScript" })
-      ).not.toBeInTheDocument();
-    });
-
-    it("should hide subcategory buttons when 전체 is selected", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      // 먼저 개발 카테고리 선택하여 서브카테고리 표시
-      fireEvent.click(screen.getByRole("button", { name: "개발" }));
-      expect(screen.getByRole("button", { name: "React" })).toBeInTheDocument();
-
-      // 전체 클릭하면 서브카테고리 숨김
-      fireEvent.click(screen.getByRole("button", { name: "전체" }));
-      expect(
-        screen.queryByRole("button", { name: "React" })
-      ).not.toBeInTheDocument();
-    });
-
-    it("should filter posts when subcategory is clicked", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "개발" }));
-      fireEvent.click(screen.getByRole("button", { name: "React" }));
-
-      expect(screen.getByText("React 시작하기")).toBeInTheDocument();
-      expect(
-        screen.queryByText("TypeScript 타입 시스템")
-      ).not.toBeInTheDocument();
-    });
-
-    it("should reset subcategory when different category is clicked", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      // 개발 > React 선택
-      fireEvent.click(screen.getByRole("button", { name: "개발" }));
-      fireEvent.click(screen.getByRole("button", { name: "React" }));
-
-      // 일상 카테고리 선택
-      fireEvent.click(screen.getByRole("button", { name: "일상" }));
-
-      // React 서브카테고리 버튼이 없어야 함
-      expect(
-        screen.queryByRole("button", { name: "React" })
-      ).not.toBeInTheDocument();
-      // 일상 포스트가 보여야 함
-      expect(screen.getByText("제주도 여행")).toBeInTheDocument();
-    });
-  });
-
-  describe("빈 결과 메시지 표시", () => {
     it("should show empty message when no posts exist", () => {
-      render(<BlogFilter posts={[]} />);
+      render(<BlogFilter {...defaultProps} posts={[]} />);
 
       expect(
         screen.getByText("아직 작성된 포스트가 없습니다.")
       ).toBeInTheDocument();
     });
 
-    it("should show category-specific empty message", () => {
-      const singleCategoryPosts: PostMeta[] = [
-        {
-          slug: "test-post",
-          title: "Test Post Title",
-          date: "2025-01-15",
-          description: "Test description",
-          category: "개발",
-          tags: [],
-          readingTime: "1 min read",
-        },
-      ];
+    it("should show category-specific empty message when category selected", () => {
+      render(
+        <BlogFilter
+          posts={[]}
+          selectedCategory="개발"
+          selectedSubcategory={null}
+        />
+      );
 
-      render(<BlogFilter posts={singleCategoryPosts} />);
+      expect(
+        screen.getByText("'개발' 카테고리에 포스트가 없습니다.")
+      ).toBeInTheDocument();
+    });
 
-      // 포스트가 표시되는지 확인
-      expect(screen.getByText("Test Post Title")).toBeInTheDocument();
+    it("should show subcategory empty message", () => {
+      render(
+        <BlogFilter
+          posts={[]}
+          selectedCategory="개발"
+          selectedSubcategory="React"
+        />
+      );
+
+      expect(
+        screen.getByText("'개발 > React' 카테고리에 포스트가 없습니다.")
+      ).toBeInTheDocument();
     });
   });
 
   describe("포스트 메타 정보 렌더링", () => {
     it("should display post category and subcategory", () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
-      // 카테고리 표시 확인
       const categoryLabels = screen.getAllByText("개발");
       expect(categoryLabels.length).toBeGreaterThan(0);
     });
 
     it("should display post tags", () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
       expect(screen.getByText("react")).toBeInTheDocument();
       expect(screen.getByText("frontend")).toBeInTheDocument();
@@ -231,35 +130,28 @@ describe("BlogFilter", () => {
     });
 
     it("should display formatted date", () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
-      // 한국어 날짜 형식 확인 (예: 2025년 1월 15일)
       expect(screen.getByText(/2025년.*1월.*15일/)).toBeInTheDocument();
-    });
-  });
-
-  describe("접근성", () => {
-    it("should use nav element for category filter", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      expect(screen.getByRole("navigation")).toBeInTheDocument();
-    });
-
-    it("should use article element for each post", () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      const articles = screen.getAllByRole("article");
-      expect(articles).toHaveLength(3);
     });
 
     it("should have proper link to blog post", () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
       const links = screen.getAllByRole("link");
       const reactPostLink = links.find((link) =>
         link.getAttribute("href")?.includes("react-post")
       );
       expect(reactPostLink).toHaveAttribute("href", "/blog/react-post");
+    });
+  });
+
+  describe("접근성", () => {
+    it("should use article element for each post", () => {
+      render(<BlogFilter {...defaultProps} />);
+
+      const articles = screen.getAllByRole("article");
+      expect(articles).toHaveLength(3);
     });
   });
 
@@ -272,20 +164,14 @@ describe("BlogFilter", () => {
       jest.useRealTimers();
     });
 
-    // 하이라이트된 텍스트도 찾을 수 있는 헬퍼 함수
-    const findTextContent = (text: string) =>
-      screen.queryByText((content, element) => {
-        return element?.textContent?.includes(text) ?? false;
-      });
-
     it("should render search input", () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
       expect(screen.getByRole("searchbox")).toBeInTheDocument();
     });
 
     it("should filter posts by search query after debounce", async () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
       const searchInput = screen.getByRole("searchbox");
 
@@ -293,22 +179,21 @@ describe("BlogFilter", () => {
         fireEvent.change(searchInput, { target: { value: "React" } });
       });
 
-      // 디바운스 대기
       act(() => {
         jest.advanceTimersByTime(300);
       });
 
       await waitFor(() => {
-        // React 관련 포스트가 표시됨 (하이라이트로 인해 article 개수로 확인)
         const articles = screen.getAllByRole("article");
         expect(articles).toHaveLength(1);
-        // React 포스트의 링크 존재 확인
-        expect(screen.getByRole("link", { name: /React 시작하기/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole("link", { name: /React 시작하기/i })
+        ).toBeInTheDocument();
       });
     });
 
     it("should search Korean text", async () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
       const searchInput = screen.getByRole("searchbox");
 
@@ -321,16 +206,16 @@ describe("BlogFilter", () => {
       });
 
       await waitFor(() => {
-        // 하나의 결과만 표시
         const articles = screen.getAllByRole("article");
         expect(articles).toHaveLength(1);
-        // 제주도 포스트 링크 확인
-        expect(screen.getByRole("link", { name: /제주도 여행/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole("link", { name: /제주도 여행/i })
+        ).toBeInTheDocument();
       });
     });
 
     it("should show no results message when search has no matches", async () => {
-      render(<BlogFilter posts={mockPosts} />);
+      render(<BlogFilter {...defaultProps} />);
 
       const searchInput = screen.getByRole("searchbox");
 
@@ -346,57 +231,6 @@ describe("BlogFilter", () => {
         expect(
           screen.getByText("'notexist'에 대한 검색 결과가 없습니다.")
         ).toBeInTheDocument();
-      });
-    });
-
-    it("should clear search when category is changed", async () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      const searchInput = screen.getByRole("searchbox");
-
-      // 검색어 입력
-      act(() => {
-        fireEvent.change(searchInput, { target: { value: "React" } });
-      });
-
-      act(() => {
-        jest.advanceTimersByTime(300);
-      });
-
-      await waitFor(() => {
-        expect(screen.getByRole("searchbox")).toHaveValue("React");
-      });
-
-      // 카테고리 변경
-      fireEvent.click(screen.getByRole("button", { name: "일상" }));
-
-      // 검색어가 초기화되어야 함
-      expect(screen.getByRole("searchbox")).toHaveValue("");
-    });
-
-    it("should combine search with category filter", async () => {
-      render(<BlogFilter posts={mockPosts} />);
-
-      // 먼저 개발 카테고리 선택
-      fireEvent.click(screen.getByRole("button", { name: "개발" }));
-
-      const searchInput = screen.getByRole("searchbox");
-
-      // TypeScript 검색 (개발 카테고리 내에서)
-      act(() => {
-        fireEvent.change(searchInput, { target: { value: "TypeScript" } });
-      });
-
-      act(() => {
-        jest.advanceTimersByTime(300);
-      });
-
-      await waitFor(() => {
-        // TypeScript 포스트만 표시 (article 1개)
-        const articles = screen.getAllByRole("article");
-        expect(articles).toHaveLength(1);
-        // TypeScript 포스트 링크 확인
-        expect(screen.getByRole("link", { name: /TypeScript 타입 시스템/i })).toBeInTheDocument();
       });
     });
   });

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { postService } from "@/lib/container";
 import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";
 import TableOfContents from "@/components/TableOfContents";
+import BlogPostSidebar from "@/components/BlogPostSidebar";
 import RelatedPosts from "@/components/RelatedPosts";
 import PostNavigation from "@/components/PostNavigation";
 import CodeBlock from "@/components/CodeBlock";
@@ -54,6 +55,7 @@ export default async function BlogPostPage({ params }: Props) {
     notFound();
   }
 
+  const allPosts = postService.getAllPosts();
   const headings = extractHeadings(post.content);
   const relatedPosts = postService.getRelatedPosts(slug, 3);
   const adjacentPosts = postService.getAdjacentPosts(slug);
@@ -73,11 +75,31 @@ export default async function BlogPostPage({ params }: Props) {
   );
 
   return (
-    <div className="relative mx-auto max-w-6xl px-4 py-16">
+    <div className="relative mx-auto max-w-7xl px-4 py-16">
       <div className="flex gap-8">
+        {/* 좌측 사이드바 - 카테고리 네비게이션 */}
+        <aside className="hidden w-56 shrink-0 xl:block">
+          <div className="sticky top-24">
+            <BlogPostSidebar posts={allPosts} currentSlug={slug} />
+          </div>
+        </aside>
+
         {/* 본문 영역 */}
         <article className="min-w-0 flex-1">
           <header className="mb-12">
+            <div className="mb-2 flex items-center gap-2">
+              <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
+                {post.category}
+              </span>
+              {post.subcategory && (
+                <>
+                  <span className="text-zinc-300 dark:text-zinc-600">/</span>
+                  <span className="text-xs text-zinc-500">
+                    {post.subcategory}
+                  </span>
+                </>
+              )}
+            </div>
             <time
               dateTime={post.date}
               className="text-sm text-zinc-500 dark:text-zinc-500"

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import { postService } from "@/lib/container";
-import BlogFilter from "@/components/BlogFilter";
+import BlogPageClient from "@/components/BlogPageClient";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -11,7 +11,7 @@ export default function BlogPage() {
   const posts = postService.getAllPosts();
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-16">
+    <div className="mx-auto max-w-6xl px-4 py-16">
       <header className="mb-12">
         <h1 className="mb-4 text-3xl font-bold">Blog</h1>
         <p className="text-zinc-600 dark:text-zinc-400">
@@ -19,7 +19,7 @@ export default function BlogPage() {
         </p>
       </header>
 
-      <BlogFilter posts={posts} />
+      <BlogPageClient posts={posts} />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,6 +115,30 @@ body::before {
   border-color: #334155;
 }
 
+/* Category Tree Sidebar */
+.category-tree-nav {
+  padding: 1rem;
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  border-radius: 0.75rem;
+  border: 1px solid #fde68a;
+}
+
+.dark .category-tree-nav {
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+  border-color: #334155;
+}
+
+/* Category Active Item */
+.category-item-active {
+  position: relative;
+  background-color: rgba(251, 191, 36, 0.08);
+  border-radius: 0.375rem;
+}
+
+.dark .category-item-active {
+  background-color: rgba(96, 165, 250, 0.1);
+}
+
 /* Fade-in animation for About page */
 @keyframes fade-in-up {
   from {

--- a/src/components/BlogPageClient.tsx
+++ b/src/components/BlogPageClient.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Suspense } from "react";
+import type { PostMeta } from "@/types";
+import { useCategoryFilter } from "@/hooks/useCategoryFilter";
+import CategoryTree from "./CategoryTree";
+import CategoryMobileFilter from "./CategoryMobileFilter";
+import BlogFilter from "./BlogFilter";
+
+interface BlogPageClientProps {
+  posts: PostMeta[];
+}
+
+function BlogPageContent({ posts }: BlogPageClientProps) {
+  const {
+    categoryTree,
+    selectedCategory,
+    selectedSubcategory,
+    filteredPosts,
+    selectCategory,
+    selectSubcategory,
+    clearFilter,
+    toggleExpanded,
+    isExpanded,
+  } = useCategoryFilter(posts);
+
+  const categoryProps = {
+    tree: categoryTree,
+    selectedCategory,
+    selectedSubcategory,
+    onSelectCategory: selectCategory,
+    onSelectSubcategory: selectSubcategory,
+    onClearFilter: clearFilter,
+    toggleExpanded,
+    isExpanded,
+    totalCount: posts.length,
+  };
+
+  return (
+    <div className="flex gap-8">
+      {/* 좌측 사이드바 - 데스크톱 전용 */}
+      <aside className="hidden w-56 shrink-0 lg:block">
+        <div className="sticky top-24">
+          <CategoryTree {...categoryProps} />
+        </div>
+      </aside>
+
+      {/* 메인 콘텐츠 */}
+      <div className="min-w-0 flex-1">
+        {/* 모바일 카테고리 필터 */}
+        <div className="mb-6">
+          <CategoryMobileFilter {...categoryProps} />
+        </div>
+
+        <BlogFilter
+          posts={filteredPosts}
+          selectedCategory={selectedCategory}
+          selectedSubcategory={selectedSubcategory}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function BlogPageClient({ posts }: BlogPageClientProps) {
+  return (
+    <Suspense fallback={null}>
+      <BlogPageContent posts={posts} />
+    </Suspense>
+  );
+}

--- a/src/components/BlogPostSidebar.tsx
+++ b/src/components/BlogPostSidebar.tsx
@@ -63,9 +63,12 @@ export default function BlogPostSidebar({
 
   return (
     <nav aria-label="카테고리 네비게이션" className="category-tree-nav">
-      <h2 className="mb-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+      <Link
+        href="/blog"
+        className="mb-4 block text-sm font-semibold text-zinc-900 hover:text-amber-700 dark:text-zinc-100 dark:hover:text-blue-400"
+      >
         카테고리
-      </h2>
+      </Link>
 
       <ul className="space-y-1">
         {categoryTree.map((category) => {
@@ -76,16 +79,19 @@ export default function BlogPostSidebar({
 
           return (
             <li key={category.name}>
-              <div className="flex items-center">
-                {/* 접기/펼치기 토글 */}
-                <button
-                  onClick={() => toggleCategory(category.name)}
-                  aria-expanded={isExpanded}
-                  aria-label={`${category.name} ${isExpanded ? "접기" : "펼치기"}`}
-                  className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
-                >
+              {/* 카테고리 행 전체 클릭으로 접기/펼치기 */}
+              <button
+                onClick={() => toggleCategory(category.name)}
+                aria-expanded={isExpanded}
+                className={`flex w-full items-center justify-between rounded-md px-2 py-2 text-sm transition-colors ${
+                  isCurrent
+                    ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                    : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                }`}
+              >
+                <span className="flex items-center gap-1">
                   <svg
-                    className={`h-3 w-3 transition-transform duration-200 ${
+                    className={`h-3 w-3 shrink-0 transition-transform duration-200 ${
                       isExpanded ? "rotate-90" : "rotate-0"
                     }`}
                     fill="none"
@@ -100,32 +106,22 @@ export default function BlogPostSidebar({
                       d="M9 5l7 7-7 7"
                     />
                   </svg>
-                </button>
-
-                {/* 카테고리 이름 */}
+                  <span>{category.name}</span>
+                </span>
                 <span
-                  className={`flex flex-1 items-center justify-between rounded-md px-2 py-2 text-sm ${
+                  className={`rounded-full px-2 py-0.5 text-xs ${
                     isCurrent
-                      ? "font-medium text-amber-700 dark:text-blue-400"
-                      : "text-zinc-600 dark:text-zinc-400"
+                      ? "bg-amber-100 text-amber-700 dark:bg-blue-900/30 dark:text-blue-400"
+                      : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
                   }`}
                 >
-                  <span>{category.name}</span>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs ${
-                      isCurrent
-                        ? "bg-amber-100 text-amber-700 dark:bg-blue-900/30 dark:text-blue-400"
-                        : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
-                    }`}
-                  >
-                    {category.count}
-                  </span>
+                  {category.count}
                 </span>
-              </div>
+              </button>
 
               {/* 서브카테고리 + 글 목록 */}
               {isExpanded && (
-                <ul className="ml-6 mt-1 space-y-2 border-l border-zinc-200 pl-3 dark:border-zinc-700">
+                <ul className="ml-4 mt-1 space-y-3 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700">
                   {/* 서브카테고리가 없는 글 */}
                   {subGroups?.has("") && (
                     <li>
@@ -134,13 +130,16 @@ export default function BlogPostSidebar({
                           <li key={post.slug}>
                             <Link
                               href={`/blog/${post.slug}`}
-                              className={`block truncate rounded-md px-2 py-1 text-xs transition-colors ${
+                              className={`flex items-start gap-1.5 rounded-md px-2 py-1 text-xs leading-relaxed transition-colors ${
                                 post.slug === currentSlug
                                   ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
-                                  : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                                  : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
                               }`}
                             >
-                              {post.title}
+                              <span className="mt-1 shrink-0 text-[8px] leading-none opacity-60">
+                                ●
+                              </span>
+                              <span className="truncate">{post.title}</span>
                             </Link>
                           </li>
                         ))}
@@ -153,37 +152,49 @@ export default function BlogPostSidebar({
                     category.subcategories.map((sub) => {
                       const postsInSub = subGroups?.get(sub.name) || [];
                       const isCurrentSub =
-                        isCurrent &&
-                        currentPost?.subcategory === sub.name;
+                        isCurrent && currentPost?.subcategory === sub.name;
 
                       return (
                         <li key={sub.name}>
-                          <span
-                            className={`flex items-center justify-between px-2 py-1 text-sm ${
+                          {/* 서브카테고리 라벨 → 블로그 목록 필터 링크 */}
+                          <Link
+                            href={`/blog?category=${encodeURIComponent(category.name)}&subcategory=${encodeURIComponent(sub.name)}`}
+                            className={`flex items-center justify-between rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wider transition-colors ${
                               isCurrentSub
-                                ? "font-medium text-amber-700 dark:text-blue-400"
-                                : "text-zinc-500 dark:text-zinc-500"
+                                ? "text-amber-700 dark:text-blue-400"
+                                : "text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
                             }`}
                           >
                             <span>{sub.name}</span>
-                            <span className="text-xs text-zinc-400 dark:text-zinc-600">
+                            <span
+                              className={`rounded-full px-1.5 py-0.5 text-[10px] font-normal ${
+                                isCurrentSub
+                                  ? "bg-amber-100 text-amber-600 dark:bg-blue-900/30 dark:text-blue-400"
+                                  : "bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-600"
+                              }`}
+                            >
                               {sub.count}
                             </span>
-                          </span>
+                          </Link>
 
                           {/* 글 링크 목록 */}
-                          <ul className="mt-0.5 space-y-0.5">
+                          <ul className="mt-1 space-y-0.5">
                             {postsInSub.map((post) => (
                               <li key={post.slug}>
                                 <Link
                                   href={`/blog/${post.slug}`}
-                                  className={`block truncate rounded-md px-2 py-1 text-xs transition-colors ${
+                                  className={`flex items-start gap-1.5 rounded-md px-2 py-1 text-xs leading-relaxed transition-colors ${
                                     post.slug === currentSlug
                                       ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
-                                      : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                                      : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
                                   }`}
                                 >
-                                  {post.title}
+                                  <span className="mt-1 shrink-0 text-[8px] leading-none opacity-60">
+                                    ●
+                                  </span>
+                                  <span className="truncate">
+                                    {post.title}
+                                  </span>
                                 </Link>
                               </li>
                             ))}

--- a/src/components/BlogPostSidebar.tsx
+++ b/src/components/BlogPostSidebar.tsx
@@ -38,7 +38,26 @@ export default function BlogPostSidebar({
     return groups;
   }, [posts]);
 
-  // 현재 글이 속한 카테고리만 펼침, 나머지는 접힘
+  // 서브카테고리 접기/펼치기 상태 (기본: 현재 글의 서브카테고리만 펼침)
+  const [collapsedSubs, setCollapsedSubs] = useState<Set<string>>(() => {
+    const initial = new Set<string>();
+    for (const category of categoryTree) {
+      for (const sub of category.subcategories) {
+        const key = `${category.name}/${sub.name}`;
+        if (
+          !(
+            category.name === currentPost?.category &&
+            sub.name === currentPost?.subcategory
+          )
+        ) {
+          initial.add(key);
+        }
+      }
+    }
+    return initial;
+  });
+
+  // 카테고리 접기/펼치기 상태 (기본: 현재 글의 카테고리만 펼침)
   const [collapsedSet, setCollapsedSet] = useState<Set<string>>(() => {
     const initial = new Set<string>();
     for (const category of categoryTree) {
@@ -61,14 +80,26 @@ export default function BlogPostSidebar({
     });
   };
 
+  const toggleSubcategory = (key: string) => {
+    setCollapsedSubs((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
   return (
-    <nav aria-label="카테고리 네비게이션" className="category-tree-nav">
-      <Link
-        href="/blog"
-        className="mb-4 block text-sm font-semibold text-zinc-900 hover:text-amber-700 dark:text-zinc-100 dark:hover:text-blue-400"
-      >
+    <nav
+      aria-label="카테고리 네비게이션"
+      className="category-tree-nav max-h-[calc(100vh-8rem)] overflow-y-auto"
+    >
+      <h2 className="mb-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
         카테고리
-      </Link>
+      </h2>
 
       <ul className="space-y-1">
         {categoryTree.map((category) => {
@@ -79,7 +110,7 @@ export default function BlogPostSidebar({
 
           return (
             <li key={category.name}>
-              {/* 카테고리 행 전체 클릭으로 접기/펼치기 */}
+              {/* 카테고리 - 클릭 시 접기/펼치기 */}
               <button
                 onClick={() => toggleCategory(category.name)}
                 aria-expanded={isExpanded}
@@ -121,7 +152,7 @@ export default function BlogPostSidebar({
 
               {/* 서브카테고리 + 글 목록 */}
               {isExpanded && (
-                <ul className="ml-4 mt-1 space-y-3 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700">
+                <ul className="ml-4 mt-1 space-y-1 border-l-2 border-zinc-200 pl-3 dark:border-zinc-700">
                   {/* 서브카테고리가 없는 글 */}
                   {subGroups?.has("") && (
                     <li>
@@ -150,22 +181,43 @@ export default function BlogPostSidebar({
                   {/* 서브카테고리별 글 */}
                   {hasSubcategories &&
                     category.subcategories.map((sub) => {
+                      const subKey = `${category.name}/${sub.name}`;
+                      const isSubExpanded = !collapsedSubs.has(subKey);
                       const postsInSub = subGroups?.get(sub.name) || [];
                       const isCurrentSub =
                         isCurrent && currentPost?.subcategory === sub.name;
 
                       return (
                         <li key={sub.name}>
-                          {/* 서브카테고리 라벨 → 블로그 목록 필터 링크 */}
-                          <Link
-                            href={`/blog?category=${encodeURIComponent(category.name)}&subcategory=${encodeURIComponent(sub.name)}`}
-                            className={`flex items-center justify-between rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wider transition-colors ${
+                          {/* 서브카테고리 - 클릭 시 접기/펼치기 */}
+                          <button
+                            onClick={() => toggleSubcategory(subKey)}
+                            aria-expanded={isSubExpanded}
+                            className={`flex w-full items-center justify-between rounded-md px-2 py-1 text-xs font-semibold uppercase tracking-wider transition-colors ${
                               isCurrentSub
                                 ? "text-amber-700 dark:text-blue-400"
                                 : "text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
                             }`}
                           >
-                            <span>{sub.name}</span>
+                            <span className="flex items-center gap-1">
+                              <svg
+                                className={`h-2.5 w-2.5 shrink-0 transition-transform duration-200 ${
+                                  isSubExpanded ? "rotate-90" : "rotate-0"
+                                }`}
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                                aria-hidden="true"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M9 5l7 7-7 7"
+                                />
+                              </svg>
+                              <span>{sub.name}</span>
+                            </span>
                             <span
                               className={`rounded-full px-1.5 py-0.5 text-[10px] font-normal ${
                                 isCurrentSub
@@ -175,30 +227,32 @@ export default function BlogPostSidebar({
                             >
                               {sub.count}
                             </span>
-                          </Link>
+                          </button>
 
                           {/* 글 링크 목록 */}
-                          <ul className="mt-1 space-y-0.5">
-                            {postsInSub.map((post) => (
-                              <li key={post.slug}>
-                                <Link
-                                  href={`/blog/${post.slug}`}
-                                  className={`flex items-start gap-1.5 rounded-md px-2 py-1 text-xs leading-relaxed transition-colors ${
-                                    post.slug === currentSlug
-                                      ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
-                                      : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-                                  }`}
-                                >
-                                  <span className="mt-1 shrink-0 text-[8px] leading-none opacity-60">
-                                    ●
-                                  </span>
-                                  <span className="truncate">
-                                    {post.title}
-                                  </span>
-                                </Link>
-                              </li>
-                            ))}
-                          </ul>
+                          {isSubExpanded && (
+                            <ul className="mt-1 space-y-0.5">
+                              {postsInSub.map((post) => (
+                                <li key={post.slug}>
+                                  <Link
+                                    href={`/blog/${post.slug}`}
+                                    className={`flex items-start gap-1.5 rounded-md px-2 py-1 text-xs leading-relaxed transition-colors ${
+                                      post.slug === currentSlug
+                                        ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                                        : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                                    }`}
+                                  >
+                                    <span className="mt-1 shrink-0 text-[8px] leading-none opacity-60">
+                                      ●
+                                    </span>
+                                    <span className="truncate">
+                                      {post.title}
+                                    </span>
+                                  </Link>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
                         </li>
                       );
                     })}

--- a/src/components/BlogPostSidebar.tsx
+++ b/src/components/BlogPostSidebar.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import type { PostMeta } from "@/types";
+import { buildCategoryTree } from "@/lib/category";
+
+interface BlogPostSidebarProps {
+  posts: PostMeta[];
+  currentSlug: string;
+}
+
+export default function BlogPostSidebar({
+  posts,
+  currentSlug,
+}: BlogPostSidebarProps) {
+  const categoryTree = useMemo(() => buildCategoryTree(posts), [posts]);
+
+  const currentPost = useMemo(
+    () => posts.find((p) => p.slug === currentSlug),
+    [posts, currentSlug]
+  );
+
+  // 글을 카테고리 → 서브카테고리로 그룹핑
+  const postGroups = useMemo(() => {
+    const groups = new Map<string, Map<string, PostMeta[]>>();
+    for (const post of posts) {
+      if (!groups.has(post.category)) {
+        groups.set(post.category, new Map());
+      }
+      const subMap = groups.get(post.category)!;
+      const subKey = post.subcategory || "";
+      if (!subMap.has(subKey)) {
+        subMap.set(subKey, []);
+      }
+      subMap.get(subKey)!.push(post);
+    }
+    return groups;
+  }, [posts]);
+
+  // 현재 글이 속한 카테고리만 펼침, 나머지는 접힘
+  const [collapsedSet, setCollapsedSet] = useState<Set<string>>(() => {
+    const initial = new Set<string>();
+    for (const category of categoryTree) {
+      if (category.name !== currentPost?.category) {
+        initial.add(category.name);
+      }
+    }
+    return initial;
+  });
+
+  const toggleCategory = (name: string) => {
+    setCollapsedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <nav aria-label="카테고리 네비게이션" className="category-tree-nav">
+      <h2 className="mb-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        카테고리
+      </h2>
+
+      <ul className="space-y-1">
+        {categoryTree.map((category) => {
+          const isExpanded = !collapsedSet.has(category.name);
+          const isCurrent = currentPost?.category === category.name;
+          const hasSubcategories = category.subcategories.length > 0;
+          const subGroups = postGroups.get(category.name);
+
+          return (
+            <li key={category.name}>
+              <div className="flex items-center">
+                {/* 접기/펼치기 토글 */}
+                <button
+                  onClick={() => toggleCategory(category.name)}
+                  aria-expanded={isExpanded}
+                  aria-label={`${category.name} ${isExpanded ? "접기" : "펼치기"}`}
+                  className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+                >
+                  <svg
+                    className={`h-3 w-3 transition-transform duration-200 ${
+                      isExpanded ? "rotate-90" : "rotate-0"
+                    }`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </button>
+
+                {/* 카테고리 이름 */}
+                <span
+                  className={`flex flex-1 items-center justify-between rounded-md px-2 py-2 text-sm ${
+                    isCurrent
+                      ? "font-medium text-amber-700 dark:text-blue-400"
+                      : "text-zinc-600 dark:text-zinc-400"
+                  }`}
+                >
+                  <span>{category.name}</span>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs ${
+                      isCurrent
+                        ? "bg-amber-100 text-amber-700 dark:bg-blue-900/30 dark:text-blue-400"
+                        : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
+                    }`}
+                  >
+                    {category.count}
+                  </span>
+                </span>
+              </div>
+
+              {/* 서브카테고리 + 글 목록 */}
+              {isExpanded && (
+                <ul className="ml-6 mt-1 space-y-2 border-l border-zinc-200 pl-3 dark:border-zinc-700">
+                  {/* 서브카테고리가 없는 글 */}
+                  {subGroups?.has("") && (
+                    <li>
+                      <ul className="space-y-0.5">
+                        {subGroups.get("")!.map((post) => (
+                          <li key={post.slug}>
+                            <Link
+                              href={`/blog/${post.slug}`}
+                              className={`block truncate rounded-md px-2 py-1 text-xs transition-colors ${
+                                post.slug === currentSlug
+                                  ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                                  : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                              }`}
+                            >
+                              {post.title}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </li>
+                  )}
+
+                  {/* 서브카테고리별 글 */}
+                  {hasSubcategories &&
+                    category.subcategories.map((sub) => {
+                      const postsInSub = subGroups?.get(sub.name) || [];
+                      const isCurrentSub =
+                        isCurrent &&
+                        currentPost?.subcategory === sub.name;
+
+                      return (
+                        <li key={sub.name}>
+                          <span
+                            className={`flex items-center justify-between px-2 py-1 text-sm ${
+                              isCurrentSub
+                                ? "font-medium text-amber-700 dark:text-blue-400"
+                                : "text-zinc-500 dark:text-zinc-500"
+                            }`}
+                          >
+                            <span>{sub.name}</span>
+                            <span className="text-xs text-zinc-400 dark:text-zinc-600">
+                              {sub.count}
+                            </span>
+                          </span>
+
+                          {/* 글 링크 목록 */}
+                          <ul className="mt-0.5 space-y-0.5">
+                            {postsInSub.map((post) => (
+                              <li key={post.slug}>
+                                <Link
+                                  href={`/blog/${post.slug}`}
+                                  className={`block truncate rounded-md px-2 py-1 text-xs transition-colors ${
+                                    post.slug === currentSlug
+                                      ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                                      : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                                  }`}
+                                >
+                                  {post.title}
+                                </Link>
+                              </li>
+                            ))}
+                          </ul>
+                        </li>
+                      );
+                    })}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/CategoryMobileFilter.tsx
+++ b/src/components/CategoryMobileFilter.tsx
@@ -9,7 +9,7 @@ interface CategoryMobileFilterProps {
   selectedCategory: string | null;
   selectedSubcategory: string | null;
   onSelectCategory: (category: string) => void;
-  onSelectSubcategory: (subcategory: string) => void;
+  onSelectSubcategory: (category: string, subcategory: string) => void;
   onClearFilter: () => void;
   toggleExpanded: (categoryName: string) => void;
   isExpanded: (categoryName: string) => boolean;
@@ -67,8 +67,8 @@ export default function CategoryMobileFilter(
               props.onSelectCategory(cat);
               setIsOpen(false);
             }}
-            onSelectSubcategory={(sub) => {
-              props.onSelectSubcategory(sub);
+            onSelectSubcategory={(cat, sub) => {
+              props.onSelectSubcategory(cat, sub);
               setIsOpen(false);
             }}
             onClearFilter={() => {

--- a/src/components/CategoryMobileFilter.tsx
+++ b/src/components/CategoryMobileFilter.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import CategoryTree from "./CategoryTree";
+import type { CategoryTree as CategoryTreeType } from "@/types";
+
+interface CategoryMobileFilterProps {
+  tree: CategoryTreeType;
+  selectedCategory: string | null;
+  selectedSubcategory: string | null;
+  onSelectCategory: (category: string) => void;
+  onSelectSubcategory: (subcategory: string) => void;
+  onClearFilter: () => void;
+  toggleExpanded: (categoryName: string) => void;
+  isExpanded: (categoryName: string) => boolean;
+  totalCount: number;
+}
+
+export default function CategoryMobileFilter(
+  props: CategoryMobileFilterProps
+) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectedLabel = props.selectedCategory
+    ? props.selectedSubcategory
+      ? `${props.selectedCategory} > ${props.selectedSubcategory}`
+      : props.selectedCategory
+    : "전체";
+
+  return (
+    <div className="lg:hidden">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-label="카테고리 필터 열기"
+        className="flex w-full items-center justify-between rounded-lg border border-zinc-200 px-4 py-3 text-sm dark:border-zinc-700"
+      >
+        <span className="text-zinc-600 dark:text-zinc-400">
+          카테고리:{" "}
+          <span className="font-medium text-zinc-900 dark:text-zinc-100">
+            {selectedLabel}
+          </span>
+        </span>
+        <svg
+          className={`h-4 w-4 text-zinc-400 transition-transform duration-200 ${
+            isOpen ? "rotate-180" : ""
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="mt-2 rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
+          <CategoryTree
+            {...props}
+            onSelectCategory={(cat) => {
+              props.onSelectCategory(cat);
+              setIsOpen(false);
+            }}
+            onSelectSubcategory={(sub) => {
+              props.onSelectSubcategory(sub);
+              setIsOpen(false);
+            }}
+            onClearFilter={() => {
+              props.onClearFilter();
+              setIsOpen(false);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CategoryTree.tsx
+++ b/src/components/CategoryTree.tsx
@@ -7,7 +7,7 @@ interface CategoryTreeProps {
   selectedCategory: string | null;
   selectedSubcategory: string | null;
   onSelectCategory: (category: string) => void;
-  onSelectSubcategory: (subcategory: string) => void;
+  onSelectSubcategory: (category: string, subcategory: string) => void;
   onClearFilter: () => void;
   toggleExpanded: (categoryName: string) => void;
   isExpanded: (categoryName: string) => boolean;
@@ -129,7 +129,7 @@ export default function CategoryTree({
                     return (
                       <li key={sub.name}>
                         <button
-                          onClick={() => onSelectSubcategory(sub.name)}
+                          onClick={() => onSelectSubcategory(category.name, sub.name)}
                           className={`flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors ${
                             isSubActive
                               ? "category-item-active font-medium text-amber-700 dark:text-blue-400"

--- a/src/components/CategoryTree.tsx
+++ b/src/components/CategoryTree.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import type { CategoryTree as CategoryTreeType } from "@/types";
+
+interface CategoryTreeProps {
+  tree: CategoryTreeType;
+  selectedCategory: string | null;
+  selectedSubcategory: string | null;
+  onSelectCategory: (category: string) => void;
+  onSelectSubcategory: (subcategory: string) => void;
+  onClearFilter: () => void;
+  toggleExpanded: (categoryName: string) => void;
+  isExpanded: (categoryName: string) => boolean;
+  totalCount: number;
+}
+
+export default function CategoryTree({
+  tree,
+  selectedCategory,
+  selectedSubcategory,
+  onSelectCategory,
+  onSelectSubcategory,
+  onClearFilter,
+  toggleExpanded,
+  isExpanded,
+  totalCount,
+}: CategoryTreeProps) {
+  return (
+    <nav aria-label="카테고리 필터" className="category-tree-nav">
+      <h2 className="mb-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        카테고리
+      </h2>
+
+      <ul className="space-y-1">
+        {/* 전체 */}
+        <li>
+          <button
+            onClick={onClearFilter}
+            className={`flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors ${
+              !selectedCategory
+                ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            }`}
+          >
+            <span>전체</span>
+            <span
+              className={`rounded-full px-2 py-0.5 text-xs ${
+                !selectedCategory
+                  ? "bg-amber-100 text-amber-700 dark:bg-blue-900/30 dark:text-blue-400"
+                  : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
+              }`}
+            >
+              {totalCount}
+            </span>
+          </button>
+        </li>
+
+        {/* 카테고리 트리 */}
+        {tree.map((category) => {
+          const isCatActive =
+            selectedCategory === category.name && !selectedSubcategory;
+          const isCatSelected = selectedCategory === category.name;
+          const expanded = isExpanded(category.name);
+          const hasSubcategories = category.subcategories.length > 0;
+
+          return (
+            <li key={category.name}>
+              <div className="flex items-center">
+                {/* 접기/펼치기 토글 */}
+                {hasSubcategories ? (
+                  <button
+                    onClick={() => toggleExpanded(category.name)}
+                    aria-expanded={expanded}
+                    aria-label={`${category.name} ${expanded ? "접기" : "펼치기"}`}
+                    className="mr-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+                  >
+                    <svg
+                      className={`h-3 w-3 transition-transform duration-200 ${
+                        expanded ? "rotate-90" : "rotate-0"
+                      }`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </button>
+                ) : (
+                  <span className="mr-1 w-5 shrink-0" />
+                )}
+
+                {/* 카테고리 버튼 */}
+                <button
+                  onClick={() => onSelectCategory(category.name)}
+                  className={`flex flex-1 items-center justify-between rounded-md px-2 py-2 text-sm transition-colors ${
+                    isCatActive
+                      ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                      : isCatSelected
+                        ? "font-medium text-zinc-900 dark:text-zinc-100"
+                        : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                  }`}
+                >
+                  <span>{category.name}</span>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs ${
+                      isCatActive
+                        ? "bg-amber-100 text-amber-700 dark:bg-blue-900/30 dark:text-blue-400"
+                        : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
+                    }`}
+                  >
+                    {category.count}
+                  </span>
+                </button>
+              </div>
+
+              {/* 서브카테고리 */}
+              {hasSubcategories && expanded && (
+                <ul className="ml-6 mt-1 space-y-0.5 border-l border-zinc-200 pl-3 dark:border-zinc-700">
+                  {category.subcategories.map((sub) => {
+                    const isSubActive =
+                      isCatSelected && selectedSubcategory === sub.name;
+
+                    return (
+                      <li key={sub.name}>
+                        <button
+                          onClick={() => onSelectSubcategory(sub.name)}
+                          className={`flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors ${
+                            isSubActive
+                              ? "category-item-active font-medium text-amber-700 dark:text-blue-400"
+                              : "text-zinc-500 hover:bg-zinc-100 hover:text-zinc-700 dark:text-zinc-500 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+                          }`}
+                        >
+                          <span>{sub.name}</span>
+                          <span
+                            className={`rounded-full px-1.5 py-0.5 text-xs ${
+                              isSubActive
+                                ? "bg-amber-100 text-amber-700 dark:bg-blue-900/30 dark:text-blue-400"
+                                : "text-zinc-400 dark:text-zinc-600"
+                            }`}
+                          >
+                            {sub.count}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/__tests__/CategoryTree.test.tsx
+++ b/src/components/__tests__/CategoryTree.test.tsx
@@ -86,7 +86,7 @@ describe("CategoryTree", () => {
     render(<CategoryTree {...defaultProps} />);
 
     fireEvent.click(screen.getByText("JavaScript"));
-    expect(mockSelectSubcategory).toHaveBeenCalledWith("JavaScript");
+    expect(mockSelectSubcategory).toHaveBeenCalledWith("개발", "JavaScript");
   });
 
   it("전체 버튼 클릭 시 onClearFilter를 호출한다", () => {

--- a/src/components/__tests__/CategoryTree.test.tsx
+++ b/src/components/__tests__/CategoryTree.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import CategoryTree from "../CategoryTree";
+import type { CategoryTree as CategoryTreeType } from "@/types";
+
+const mockSelectCategory = jest.fn();
+const mockSelectSubcategory = jest.fn();
+const mockClearFilter = jest.fn();
+const mockToggleExpanded = jest.fn();
+const mockIsExpanded = jest.fn().mockReturnValue(true);
+
+const sampleTree: CategoryTreeType = [
+  {
+    name: "개발",
+    count: 5,
+    subcategories: [
+      { name: "JavaScript", count: 2 },
+      { name: "Next.js", count: 3 },
+    ],
+  },
+  {
+    name: "주식",
+    count: 2,
+    subcategories: [{ name: "분석", count: 2 }],
+  },
+];
+
+const defaultProps = {
+  tree: sampleTree,
+  selectedCategory: null as string | null,
+  selectedSubcategory: null as string | null,
+  onSelectCategory: mockSelectCategory,
+  onSelectSubcategory: mockSelectSubcategory,
+  onClearFilter: mockClearFilter,
+  toggleExpanded: mockToggleExpanded,
+  isExpanded: mockIsExpanded,
+  totalCount: 7,
+};
+
+describe("CategoryTree", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsExpanded.mockReturnValue(true);
+  });
+
+  it("카테고리 트리를 렌더링한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    expect(screen.getByText("개발")).toBeInTheDocument();
+    expect(screen.getByText("주식")).toBeInTheDocument();
+  });
+
+  it("각 카테고리 옆에 글 개수를 표시한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    // "개발" 카테고리의 count 5가 표시
+    expect(screen.getByText("5")).toBeInTheDocument();
+    // "주식" 카테고리의 count가 표시 (여러 개의 "2"가 있으므로 getAllByText 사용)
+    const twos = screen.getAllByText("2");
+    expect(twos.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("서브카테고리를 표시한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    expect(screen.getByText("JavaScript")).toBeInTheDocument();
+    expect(screen.getByText("Next.js")).toBeInTheDocument();
+    expect(screen.getByText("분석")).toBeInTheDocument();
+  });
+
+  it("전체 버튼을 표시하고 전체 글 수를 보여준다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    expect(screen.getByText("전체")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("카테고리 클릭 시 onSelectCategory를 호출한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("개발"));
+    expect(mockSelectCategory).toHaveBeenCalledWith("개발");
+  });
+
+  it("서브카테고리 클릭 시 onSelectSubcategory를 호출한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("JavaScript"));
+    expect(mockSelectSubcategory).toHaveBeenCalledWith("JavaScript");
+  });
+
+  it("전체 버튼 클릭 시 onClearFilter를 호출한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("전체"));
+    expect(mockClearFilter).toHaveBeenCalled();
+  });
+
+  it("선택된 카테고리를 강조 표시한다", () => {
+    render(<CategoryTree {...defaultProps} selectedCategory="개발" />);
+
+    const devButton = screen.getByText("개발").closest("button");
+    expect(devButton?.className).toContain("category-item-active");
+  });
+
+  it("접힌 카테고리의 서브카테고리를 숨긴다", () => {
+    mockIsExpanded.mockImplementation((name: string) => name !== "개발");
+
+    render(<CategoryTree {...defaultProps} />);
+
+    // 주식의 서브카테고리는 보임
+    expect(screen.getByText("분석")).toBeInTheDocument();
+    // 개발의 서브카테고리는 숨겨짐 (접힌 상태)
+    expect(screen.queryByText("JavaScript")).not.toBeInTheDocument();
+  });
+
+  it("nav 요소에 aria-label을 설정한다", () => {
+    render(<CategoryTree {...defaultProps} />);
+
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveAttribute("aria-label", "카테고리 필터");
+  });
+});

--- a/src/hooks/__tests__/useCategoryFilter.test.ts
+++ b/src/hooks/__tests__/useCategoryFilter.test.ts
@@ -83,12 +83,10 @@ describe("useCategoryFilter", () => {
     const { result } = renderHook(() => useCategoryFilter(samplePosts));
 
     act(() => {
-      result.current.selectCategory("개발");
-    });
-    act(() => {
-      result.current.selectSubcategory("JavaScript");
+      result.current.selectSubcategory("개발", "JavaScript");
     });
 
+    expect(result.current.selectedCategory).toBe("개발");
     expect(result.current.selectedSubcategory).toBe("JavaScript");
     expect(result.current.filteredPosts).toHaveLength(1);
     expect(result.current.filteredPosts[0].slug).toBe("p1");
@@ -112,13 +110,10 @@ describe("useCategoryFilter", () => {
     const { result } = renderHook(() => useCategoryFilter(samplePosts));
 
     act(() => {
-      result.current.selectCategory("개발");
+      result.current.selectSubcategory("개발", "JavaScript");
     });
     act(() => {
-      result.current.selectSubcategory("JavaScript");
-    });
-    act(() => {
-      result.current.selectSubcategory("JavaScript");
+      result.current.selectSubcategory("개발", "JavaScript");
     });
 
     expect(result.current.selectedCategory).toBe("개발");
@@ -130,10 +125,7 @@ describe("useCategoryFilter", () => {
     const { result } = renderHook(() => useCategoryFilter(samplePosts));
 
     act(() => {
-      result.current.selectCategory("개발");
-    });
-    act(() => {
-      result.current.selectSubcategory("JavaScript");
+      result.current.selectSubcategory("개발", "JavaScript");
     });
     act(() => {
       result.current.clearFilter();
@@ -142,6 +134,23 @@ describe("useCategoryFilter", () => {
     expect(result.current.selectedCategory).toBeNull();
     expect(result.current.selectedSubcategory).toBeNull();
     expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("전체 상태에서 서브카테고리 직접 선택 시 부모 카테고리도 함께 설정한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    // 초기 상태: 전체 (카테고리 미선택)
+    expect(result.current.selectedCategory).toBeNull();
+
+    // 서브카테고리 직접 선택
+    act(() => {
+      result.current.selectSubcategory("개발", "JavaScript");
+    });
+
+    expect(result.current.selectedCategory).toBe("개발");
+    expect(result.current.selectedSubcategory).toBe("JavaScript");
+    expect(result.current.filteredPosts).toHaveLength(1);
+    expect(result.current.filteredPosts[0].slug).toBe("p1");
   });
 
   it("트리 노드 접기/펼치기를 토글한다", () => {

--- a/src/hooks/__tests__/useCategoryFilter.test.ts
+++ b/src/hooks/__tests__/useCategoryFilter.test.ts
@@ -1,0 +1,185 @@
+import { renderHook, act } from "@testing-library/react";
+import { useCategoryFilter } from "../useCategoryFilter";
+import type { PostMeta } from "@/types";
+
+// Next.js useSearchParams/useRouter mock
+const mockPush = jest.fn();
+const mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/blog",
+}));
+
+const createPost = (overrides: Partial<PostMeta> = {}): PostMeta => ({
+  slug: "test-post",
+  title: "Test Post",
+  date: "2026-01-01",
+  description: "Test description",
+  category: "개발",
+  tags: [],
+  readingTime: "5 min",
+  ...overrides,
+});
+
+const samplePosts: PostMeta[] = [
+  createPost({ slug: "p1", category: "개발", subcategory: "JavaScript" }),
+  createPost({ slug: "p2", category: "개발", subcategory: "Next.js" }),
+  createPost({ slug: "p3", category: "주식", subcategory: "분석" }),
+  createPost({ slug: "p4", category: "개발" }),
+];
+
+describe("useCategoryFilter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // reset search params
+    [...mockSearchParams.keys()].forEach((key) =>
+      mockSearchParams.delete(key)
+    );
+  });
+
+  it("초기 상태에서 카테고리 선택 없이 전체 포스트를 반환한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    expect(result.current.selectedCategory).toBeNull();
+    expect(result.current.selectedSubcategory).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("카테고리 트리를 올바르게 생성한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    expect(result.current.categoryTree).toHaveLength(2);
+    const dev = result.current.categoryTree.find((c) => c.name === "개발");
+    expect(dev?.count).toBe(3);
+    expect(dev?.subcategories).toHaveLength(2);
+  });
+
+  it("카테고리 선택 시 해당 카테고리 포스트만 필터링한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+
+    expect(result.current.selectedCategory).toBe("개발");
+    expect(result.current.filteredPosts).toHaveLength(3);
+  });
+
+  it("카테고리 선택 시 URL을 업데이트한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/blog?category=%EA%B0%9C%EB%B0%9C", {
+      scroll: false,
+    });
+  });
+
+  it("서브카테고리 선택 시 해당 포스트만 필터링한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+    act(() => {
+      result.current.selectSubcategory("JavaScript");
+    });
+
+    expect(result.current.selectedSubcategory).toBe("JavaScript");
+    expect(result.current.filteredPosts).toHaveLength(1);
+    expect(result.current.filteredPosts[0].slug).toBe("p1");
+  });
+
+  it("같은 카테고리 재클릭 시 선택을 해제한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+
+    expect(result.current.selectedCategory).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("같은 서브카테고리 재클릭 시 서브카테고리만 해제한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+    act(() => {
+      result.current.selectSubcategory("JavaScript");
+    });
+    act(() => {
+      result.current.selectSubcategory("JavaScript");
+    });
+
+    expect(result.current.selectedCategory).toBe("개발");
+    expect(result.current.selectedSubcategory).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(3);
+  });
+
+  it("clearFilter가 모든 필터를 해제한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    act(() => {
+      result.current.selectCategory("개발");
+    });
+    act(() => {
+      result.current.selectSubcategory("JavaScript");
+    });
+    act(() => {
+      result.current.clearFilter();
+    });
+
+    expect(result.current.selectedCategory).toBeNull();
+    expect(result.current.selectedSubcategory).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("트리 노드 접기/펼치기를 토글한다", () => {
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    // 기본: 모두 펼쳐진 상태
+    expect(result.current.isExpanded("개발")).toBe(true);
+
+    // 접기
+    act(() => {
+      result.current.toggleExpanded("개발");
+    });
+    expect(result.current.isExpanded("개발")).toBe(false);
+
+    // 다시 펼치기
+    act(() => {
+      result.current.toggleExpanded("개발");
+    });
+    expect(result.current.isExpanded("개발")).toBe(true);
+  });
+
+  it("URL 파라미터에서 초기 카테고리를 읽는다", () => {
+    mockSearchParams.set("category", "개발");
+
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    expect(result.current.selectedCategory).toBe("개발");
+    expect(result.current.filteredPosts).toHaveLength(3);
+  });
+
+  it("URL 파라미터에서 초기 서브카테고리를 읽는다", () => {
+    mockSearchParams.set("category", "개발");
+    mockSearchParams.set("subcategory", "JavaScript");
+
+    const { result } = renderHook(() => useCategoryFilter(samplePosts));
+
+    expect(result.current.selectedCategory).toBe("개발");
+    expect(result.current.selectedSubcategory).toBe("JavaScript");
+    expect(result.current.filteredPosts).toHaveLength(1);
+  });
+});

--- a/src/hooks/useCategoryFilter.ts
+++ b/src/hooks/useCategoryFilter.ts
@@ -57,16 +57,17 @@ export function useCategoryFilter(posts: PostMeta[]) {
     [selectedCategory, updateURL]
   );
 
-  // 서브카테고리 선택/해제
+  // 서브카테고리 선택/해제 (부모 카테고리도 함께 설정)
   const selectSubcategory = useCallback(
-    (subcategory: string) => {
-      if (selectedSubcategory === subcategory) {
-        // 같은 서브카테고리 재클릭 -> 서브만 해제
+    (category: string, subcategory: string) => {
+      if (selectedCategory === category && selectedSubcategory === subcategory) {
+        // 같은 서브카테고리 재클릭 -> 카테고리 선택 상태로 복귀
         setSelectedSubcategory(null);
-        updateURL(selectedCategory, null);
+        updateURL(category, null);
       } else {
+        setSelectedCategory(category);
         setSelectedSubcategory(subcategory);
-        updateURL(selectedCategory, subcategory);
+        updateURL(category, subcategory);
       }
     },
     [selectedCategory, selectedSubcategory, updateURL]

--- a/src/hooks/useCategoryFilter.ts
+++ b/src/hooks/useCategoryFilter.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import type { PostMeta, CategoryTree } from "@/types";
+import { buildCategoryTree } from "@/lib/category";
+
+export function useCategoryFilter(posts: PostMeta[]) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // URL에서 초기값 읽기
+  const initialCategory = searchParams.get("category");
+  const initialSubcategory = searchParams.get("subcategory");
+
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(
+    initialCategory
+  );
+  const [selectedSubcategory, setSelectedSubcategory] = useState<string | null>(
+    initialSubcategory
+  );
+  const [collapsedSet, setCollapsedSet] = useState<Set<string>>(new Set());
+
+  // 카테고리 트리 빌드
+  const categoryTree: CategoryTree = useMemo(
+    () => buildCategoryTree(posts),
+    [posts]
+  );
+
+  // URL 업데이트
+  const updateURL = useCallback(
+    (category: string | null, subcategory: string | null) => {
+      const params = new URLSearchParams();
+      if (category) params.set("category", category);
+      if (subcategory) params.set("subcategory", subcategory);
+      const query = params.toString();
+      router.push(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
+    },
+    [router, pathname]
+  );
+
+  // 카테고리 선택/해제
+  const selectCategory = useCallback(
+    (category: string) => {
+      if (selectedCategory === category) {
+        // 같은 카테고리 재클릭 -> 해제
+        setSelectedCategory(null);
+        setSelectedSubcategory(null);
+        updateURL(null, null);
+      } else {
+        setSelectedCategory(category);
+        setSelectedSubcategory(null);
+        updateURL(category, null);
+      }
+    },
+    [selectedCategory, updateURL]
+  );
+
+  // 서브카테고리 선택/해제
+  const selectSubcategory = useCallback(
+    (subcategory: string) => {
+      if (selectedSubcategory === subcategory) {
+        // 같은 서브카테고리 재클릭 -> 서브만 해제
+        setSelectedSubcategory(null);
+        updateURL(selectedCategory, null);
+      } else {
+        setSelectedSubcategory(subcategory);
+        updateURL(selectedCategory, subcategory);
+      }
+    },
+    [selectedCategory, selectedSubcategory, updateURL]
+  );
+
+  // 전체 필터 해제
+  const clearFilter = useCallback(() => {
+    setSelectedCategory(null);
+    setSelectedSubcategory(null);
+    updateURL(null, null);
+  }, [updateURL]);
+
+  // 트리 접기/펼치기
+  const toggleExpanded = useCallback((categoryName: string) => {
+    setCollapsedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(categoryName)) {
+        next.delete(categoryName);
+      } else {
+        next.add(categoryName);
+      }
+      return next;
+    });
+  }, []);
+
+  const isExpanded = useCallback(
+    (categoryName: string) => !collapsedSet.has(categoryName),
+    [collapsedSet]
+  );
+
+  // 필터링된 포스트
+  const filteredPosts = useMemo(() => {
+    if (!selectedCategory) return posts;
+    if (selectedSubcategory) {
+      return posts.filter(
+        (p) =>
+          p.category === selectedCategory &&
+          p.subcategory === selectedSubcategory
+      );
+    }
+    return posts.filter((p) => p.category === selectedCategory);
+  }, [posts, selectedCategory, selectedSubcategory]);
+
+  return {
+    categoryTree,
+    selectedCategory,
+    selectedSubcategory,
+    filteredPosts,
+    selectCategory,
+    selectSubcategory,
+    clearFilter,
+    toggleExpanded,
+    isExpanded,
+  };
+}

--- a/src/lib/__tests__/category.test.ts
+++ b/src/lib/__tests__/category.test.ts
@@ -1,0 +1,112 @@
+import { buildCategoryTree } from "../category";
+import type { PostMeta } from "@/types";
+
+const createPost = (
+  overrides: Partial<PostMeta> = {}
+): PostMeta => ({
+  slug: "test-post",
+  title: "Test Post",
+  date: "2026-01-01",
+  description: "Test description",
+  category: "개발",
+  tags: [],
+  readingTime: "5 min",
+  ...overrides,
+});
+
+describe("buildCategoryTree", () => {
+  it("빈 배열 입력 시 빈 트리를 반환한다", () => {
+    const result = buildCategoryTree([]);
+    expect(result).toEqual([]);
+  });
+
+  it("단일 카테고리, 서브카테고리 없는 포스트를 처리한다", () => {
+    const posts = [createPost({ slug: "p1", category: "개발" })];
+    const result = buildCategoryTree(posts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      name: "개발",
+      count: 1,
+      subcategories: [],
+    });
+  });
+
+  it("동일 카테고리의 여러 서브카테고리를 처리한다", () => {
+    const posts = [
+      createPost({ slug: "p1", category: "개발", subcategory: "JavaScript" }),
+      createPost({ slug: "p2", category: "개발", subcategory: "Next.js" }),
+      createPost({ slug: "p3", category: "개발", subcategory: "JavaScript" }),
+    ];
+    const result = buildCategoryTree(posts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("개발");
+    expect(result[0].count).toBe(3);
+    expect(result[0].subcategories).toHaveLength(2);
+
+    const jsSub = result[0].subcategories.find((s) => s.name === "JavaScript");
+    const nextSub = result[0].subcategories.find((s) => s.name === "Next.js");
+    expect(jsSub?.count).toBe(2);
+    expect(nextSub?.count).toBe(1);
+  });
+
+  it("서브카테고리가 있는 포스트와 없는 포스트를 혼합 처리한다", () => {
+    const posts = [
+      createPost({ slug: "p1", category: "개발", subcategory: "JavaScript" }),
+      createPost({ slug: "p2", category: "개발" }),
+    ];
+    const result = buildCategoryTree(posts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
+    expect(result[0].subcategories).toHaveLength(1);
+    expect(result[0].subcategories[0]).toEqual({
+      name: "JavaScript",
+      count: 1,
+    });
+  });
+
+  it("여러 카테고리를 가나다순으로 정렬한다", () => {
+    const posts = [
+      createPost({ slug: "p1", category: "주식" }),
+      createPost({ slug: "p2", category: "개발" }),
+      createPost({ slug: "p3", category: "책" }),
+      createPost({ slug: "p4", category: "일상" }),
+    ];
+    const result = buildCategoryTree(posts);
+
+    expect(result.map((c) => c.name)).toEqual(["개발", "일상", "주식", "책"]);
+  });
+
+  it("서브카테고리를 가나다순으로 정렬한다", () => {
+    const posts = [
+      createPost({ slug: "p1", category: "개발", subcategory: "웹" }),
+      createPost({ slug: "p2", category: "개발", subcategory: "Java" }),
+      createPost({ slug: "p3", category: "개발", subcategory: "Next.js" }),
+    ];
+    const result = buildCategoryTree(posts);
+
+    expect(result[0].subcategories.map((s) => s.name)).toEqual([
+      "Java",
+      "Next.js",
+      "웹",
+    ]);
+  });
+
+  it("각 카테고리의 count가 정확하다", () => {
+    const posts = [
+      createPost({ slug: "p1", category: "개발", subcategory: "JavaScript" }),
+      createPost({ slug: "p2", category: "개발", subcategory: "Next.js" }),
+      createPost({ slug: "p3", category: "주식", subcategory: "분석" }),
+      createPost({ slug: "p4", category: "개발" }),
+    ];
+    const result = buildCategoryTree(posts);
+
+    const dev = result.find((c) => c.name === "개발");
+    const stock = result.find((c) => c.name === "주식");
+
+    expect(dev?.count).toBe(3);
+    expect(stock?.count).toBe(1);
+  });
+});

--- a/src/lib/category.ts
+++ b/src/lib/category.ts
@@ -1,0 +1,53 @@
+import type { PostMeta, CategoryTree, CategoryNode, SubcategoryNode } from "@/types";
+
+/**
+ * 포스트 목록에서 카테고리 트리를 생성한다.
+ * - 실제 글이 있는 카테고리만 포함
+ * - 카테고리/서브카테고리 모두 가나다순 정렬
+ */
+export function buildCategoryTree(posts: PostMeta[]): CategoryTree {
+  if (posts.length === 0) return [];
+
+  const categoryMap = new Map<
+    string,
+    { count: number; subcategories: Map<string, number> }
+  >();
+
+  for (const post of posts) {
+    const entry = categoryMap.get(post.category) ?? {
+      count: 0,
+      subcategories: new Map<string, number>(),
+    };
+
+    entry.count += 1;
+
+    if (post.subcategory) {
+      const subCount = entry.subcategories.get(post.subcategory) ?? 0;
+      entry.subcategories.set(post.subcategory, subCount + 1);
+    }
+
+    categoryMap.set(post.category, entry);
+  }
+
+  const tree: CategoryNode[] = [];
+
+  for (const [name, entry] of categoryMap) {
+    const subcategories: SubcategoryNode[] = [];
+
+    for (const [subName, subCount] of entry.subcategories) {
+      subcategories.push({ name: subName, count: subCount });
+    }
+
+    subcategories.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    tree.push({
+      name,
+      count: entry.count,
+      subcategories,
+    });
+  }
+
+  tree.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  return tree;
+}

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,0 +1,21 @@
+/**
+ * 서브카테고리 노드
+ */
+export interface SubcategoryNode {
+  name: string;
+  count: number;
+}
+
+/**
+ * 카테고리 노드 (대분류)
+ */
+export interface CategoryNode {
+  name: string;
+  count: number;
+  subcategories: SubcategoryNode[];
+}
+
+/**
+ * 카테고리 트리 (전체 구조)
+ */
+export type CategoryTree = CategoryNode[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export type { Post, PostMeta, PostFrontmatter } from "./post";
 export type { GlossaryEntry } from "./glossary";
 export type { Project } from "./project";
 export type { SearchResult, SearchMatch, SearchOptions } from "./search";
+export type { CategoryNode, SubcategoryNode, CategoryTree } from "./category";


### PR DESCRIPTION
## Summary
- 블로그 글 목록 페이지에 카테고리 트리 사이드바 추가 (카테고리 → 서브카테고리 계층 구조)
- 블로그 글 상세 페이지에 카테고리 네비게이션 사이드바 추가 (카테고리 → 서브카테고리 → 글 제목 링크)
- 카테고리/서브카테고리 접기/펼치기, URL 기반 필터 상태 관리, 모바일 드롭다운 필터 지원
- 전체 상태에서 서브카테고리 직접 선택 시 필터링이 동작하지 않던 버그 수정

## Changes
- **신규**: `CategoryTree`, `CategoryMobileFilter`, `BlogPageClient`, `BlogPostSidebar` 컴포넌트
- **신규**: `useCategoryFilter` 훅 (URL 파라미터 연동, 카테고리 선택/해제/접기/펼치기)
- **신규**: `buildCategoryTree` 유틸리티, `CategoryTree` 타입 정의
- **수정**: `BlogFilter` 카테고리 로직 분리, `blog/[slug]/page.tsx` 3컬럼 레이아웃
- **테스트**: CategoryTree, useCategoryFilter, buildCategoryTree 테스트 추가 (279 tests all pass)

## Test plan
- [x] 블로그 목록에서 카테고리/서브카테고리 선택 시 글 필터링 확인
- [x] "전체" 상태에서 서브카테고리 직접 클릭 시 필터링 동작 확인
- [x] 글 상세 페이지에서 좌측 카테고리 트리 표시 및 글 간 이동 확인
- [x] 카테고리/서브카테고리 접기/펼치기 동작 확인
- [x] 모바일에서 드롭다운 필터 동작 확인
- [x] URL 파라미터 기반 필터 상태 유지 확인