### PR TITLE
fix: 브라우저 캐시 가이드 볼드 렌더링 수정 및 참고 자료 추가

### DIFF
--- a/content/posts/browser-cache-guide.md
+++ b/content/posts/browser-cache-guide.md
@@ -47,7 +47,7 @@ glossary:
 매번 동일한 리소스를 반복해서 받는 것은 네트워크 트래픽 낭비이자 사용자 경험 저하의 원인이 됩니다.
 
 HTTP 캐싱은 이전에 가져온 리소스를 재사용하여 이 문제를 해결합니다.
-캐시의 핵심은 **저장(Store)**과 **재사용(Reuse)** 두 단계로 구성되며, 브라우저는 이 과정을 **강력 캐시**와 **협상 캐시**라는 두 가지 전략으로 처리합니다.
+캐시의 핵심은 <strong>저장(Store)</strong>과 <strong>재사용(Reuse)</strong> 두 단계로 구성되며, 브라우저는 이 과정을 **강력 캐시**와 **협상 캐시**라는 두 가지 전략으로 처리합니다.
 
 | 구분 | <Term id="strong-cache">강력 캐시</Term> | <Term id="negotiated-cache">협상 캐시</Term> |
 |------|------|------|
@@ -325,7 +325,7 @@ GET /api/servers?keyword=web     → 캐시 히트 [A]
 GET /api/servers?keyword=web&page=2  → 서버 요청 → 캐시 저장 [C]
 ```
 
-POST는 HTTP 스펙(RFC 7231)에서 **부수 효과(side effect)**가 있는 메서드로 정의됩니다.
+POST는 HTTP 스펙(RFC 7231)에서 <strong>부수 효과(side effect)</strong>가 있는 메서드로 정의됩니다.
 같은 요청을 보내도 서버 상태가 변경될 수 있으므로, 브라우저는 POST 응답을 캐시하지 않습니다.
 
 <details>

--- a/content/posts/browser-cache-guide.md
+++ b/content/posts/browser-cache-guide.md
@@ -486,3 +486,8 @@ Chrome DevTools의 Network 탭에서 캐시 동작을 확인할 수 있습니다
 | Cache Busting | URL에 해시를 삽입하는 것이 가장 안정적인 캐시 무효화 전략 |
 | 휴리스틱 캐싱 | 모든 응답에 Cache-Control을 명시하여 방지 |
 | 베스트 프랙티스 | ETag와 Last-Modified를 함께 제공 |
+
+## 참고 자료
+
+- [HTTP Caching - MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching)
+- [헷갈리는 캐시 설정, 쉽게 정리해 드립니다(feat Cache-Control)](https://www.youtube.com/watch?v=iCo0Sz2736Y&t=1s)


### PR DESCRIPTION
## Summary
- CommonMark 파서가 `**텍스트(괄호)**` 패턴의 닫는 delimiter를 인식하지 못해 `**` 문자가 그대로 출력되는 문제를 `<strong>` 태그로 수정
- 글 하단에 참고 자료 섹션 추가 (MDN HTTP Caching, YouTube 영상)

## Changes

### 볼드 렌더링 수정
| 위치 | 변경 전 | 변경 후 |
|------|---------|---------|
| Line 50 | `**저장(Store)**` | `<strong>저장(Store)</strong>` |
| Line 50 | `**재사용(Reuse)**` | `<strong>재사용(Reuse)</strong>` |
| Line 328 | `**부수 효과(side effect)**` | `<strong>부수 효과(side effect)</strong>` |

### 참고 자료 추가
- [HTTP Caching - MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching)
- [헷갈리는 캐시 설정, 쉽게 정리해 드립니다(feat Cache-Control)](https://www.youtube.com/watch?v=iCo0Sz2736Y&t=1s)

## Root Cause
CommonMark 스펙에서 닫는 `**`가 right-flanking delimiter로 인식되려면, 앞에 구두점(`)`)이 올 경우 뒤에 공백 또는 구두점이 와야 합니다. `)**과` 패턴은 `)` 뒤에 한글이 오기 때문에 delimiter로 인식되지 않습니다.

## Test plan
- [ ] `저장(Store)`, `재사용(Reuse)`, `부수 효과(side effect)` 볼드 렌더링 확인
- [ ] 기존 `**강력 캐시**`, `**협상 캐시**` 등 정상 볼드 유지 확인
- [ ] 참고 자료 링크 정상 동작 확인