### PR TITLE
perf(blog): MDX 본문 이미지 lazy loading 적용 (#90)

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import rehypePrettyCode from "rehype-pretty-code";
 import type { Options as PrettyCodeOptions } from "rehype-pretty-code";
-import { addLazyLoading } from "@/lib/rehype-lazy-loading";
+import { addLazyLoading } from "@/lib/mdx-lazy-loading";
 import { postService } from "@/lib/container";
 import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import rehypePrettyCode from "rehype-pretty-code";
 import type { Options as PrettyCodeOptions } from "rehype-pretty-code";
+import { addLazyLoading } from "@/lib/rehype-lazy-loading";
 import { postService } from "@/lib/container";
 import { extractHeadings } from "@/lib/toc";
 import { DATE_FORMAT } from "@/lib/constants";
@@ -70,7 +71,7 @@ export default async function BlogPostPage({ params }: Props) {
 
   const mdxContent = (
     <MDXRemote
-      source={post.content}
+      source={addLazyLoading(post.content)}
       components={{ Term, pre: CodeBlock }}
       options={{
         mdxOptions: {

--- a/src/lib/__tests__/rehype-lazy-loading.test.ts
+++ b/src/lib/__tests__/rehype-lazy-loading.test.ts
@@ -1,0 +1,62 @@
+import { addLazyLoading } from "../rehype-lazy-loading";
+
+describe("addLazyLoading", () => {
+  it("img 요소에 loading='lazy'를 추가한다", () => {
+    const input = '<img src="/images/test.png" alt="test" />';
+    const output = addLazyLoading(input);
+    expect(output).toContain('loading="lazy"');
+    expect(output).toContain('src="/images/test.png"');
+  });
+
+  it("이미 loading 속성이 있는 img는 스킵한다", () => {
+    const input = '<img loading="eager" src="/images/test.png" />';
+    const output = addLazyLoading(input);
+    expect(output).toContain('loading="eager"');
+    expect(output).not.toContain('loading="lazy"');
+  });
+
+  it("img 외 요소는 영향받지 않는다", () => {
+    const input = "<p>hello</p><span>world</span>";
+    const output = addLazyLoading(input);
+    expect(output).toBe(input);
+  });
+
+  it("중첩 구조 내 img도 처리한다 (figure > div > img)", () => {
+    const input = `<figure>
+  <div className="image-frame">
+    <img className="theme-light" src="/images/posts/test-light.png" alt="test" />
+    <img className="theme-dark" src="/images/posts/test-dark.png" alt="test" />
+  </div>
+</figure>`;
+    const output = addLazyLoading(input);
+    const matches = output.match(/loading="lazy"/g);
+    expect(matches).toHaveLength(2);
+  });
+
+  it("여러 img 요소를 모두 처리한다", () => {
+    const input = `<img src="/a.png" />
+<img src="/b.png" />
+<img src="/c.png" />`;
+    const output = addLazyLoading(input);
+    const matches = output.match(/loading="lazy"/g);
+    expect(matches).toHaveLength(3);
+  });
+
+  it("self-closing이 아닌 img도 처리한다", () => {
+    const input = '<img src="/test.png">';
+    const output = addLazyLoading(input);
+    expect(output).toContain('loading="lazy"');
+  });
+
+  it("혼합: loading 있는 img와 없는 img를 올바르게 구분한다", () => {
+    const input = `<img loading="eager" src="/a.png" />
+<img src="/b.png" />
+<img loading="lazy" src="/c.png" />`;
+    const output = addLazyLoading(input);
+    expect(output).toContain('<img loading="eager"');
+    expect(output).toContain('<img loading="lazy" src="/b.png"');
+    expect(output).toContain('<img loading="lazy" src="/c.png"');
+    const lazyMatches = output.match(/loading="lazy"/g);
+    expect(lazyMatches).toHaveLength(2);
+  });
+});

--- a/src/lib/__tests__/rehype-lazy-loading.test.ts
+++ b/src/lib/__tests__/rehype-lazy-loading.test.ts
@@ -1,4 +1,4 @@
-import { addLazyLoading } from "../rehype-lazy-loading";
+import { addLazyLoading } from "../mdx-lazy-loading";
 
 describe("addLazyLoading", () => {
   it("img 요소에 loading='lazy'를 추가한다", () => {
@@ -58,5 +58,26 @@ describe("addLazyLoading", () => {
     expect(output).toContain('<img loading="lazy" src="/c.png"');
     const lazyMatches = output.match(/loading="lazy"/g);
     expect(lazyMatches).toHaveLength(2);
+  });
+
+  it("멀티라인 img 태그도 처리한다", () => {
+    const input = `<img
+  className="theme-light"
+  src="/images/posts/test-light.png"
+  alt="test"
+/>`;
+    const output = addLazyLoading(input);
+    expect(output).toContain('loading="lazy"');
+  });
+
+  it("멀티라인 img 태그에 이미 loading이 있으면 스킵한다", () => {
+    const input = `<img
+  loading="eager"
+  className="theme-light"
+  src="/test.png"
+/>`;
+    const output = addLazyLoading(input);
+    expect(output).toContain('loading="eager"');
+    expect(output).not.toContain('loading="lazy"');
   });
 });

--- a/src/lib/mdx-lazy-loading.ts
+++ b/src/lib/mdx-lazy-loading.ts
@@ -6,10 +6,11 @@
  *
  * - 이미 loading 속성이 있는 <img>는 스킵한다.
  * - <img 이외의 태그는 영향받지 않는다.
+ * - 멀티라인 <img> 태그도 지원한다.
  */
 export function addLazyLoading(source: string): string {
   return source.replace(
-    /<img(?![^>]*\bloading\b)([^>]*?)(\/?>)/g,
+    /<img(?![^>]*\bloading\b)([^>]*)(\/?>)/g,
     '<img loading="lazy"$1$2'
   );
 }

--- a/src/lib/rehype-lazy-loading.ts
+++ b/src/lib/rehype-lazy-loading.ts
@@ -1,0 +1,15 @@
+/**
+ * MDX 소스 문자열에서 <img> 태그에 loading="lazy" 속성을 추가한다.
+ *
+ * MDX의 JSX <img> 요소는 rehype 파이프라인을 통한 속성 주입이 불가능하므로,
+ * MDX 컴파일 전 소스 문자열을 전처리하는 방식을 사용한다.
+ *
+ * - 이미 loading 속성이 있는 <img>는 스킵한다.
+ * - <img 이외의 태그는 영향받지 않는다.
+ */
+export function addLazyLoading(source: string): string {
+  return source.replace(
+    /<img(?![^>]*\bloading\b)([^>]*?)(\/?>)/g,
+    '<img loading="lazy"$1$2'
+  );
+}


### PR DESCRIPTION
## Summary
- MDX 본문의 모든 `<img>` 태그에 `loading="lazy"` 자동 삽입
- MDX의 JSX `<img>`는 rehype 파이프라인으로 속성 주입이 불가하여 소스 전처리 방식 적용
- 단위 테스트 9개 추가 (멀티라인 img 포함)

## 변경 파일
| 파일 | 변경 | 설명 |
|------|------|------|
| `src/lib/mdx-lazy-loading.ts` | 추가 | `addLazyLoading` 전처리 함수 |
| `src/lib/__tests__/rehype-lazy-loading.test.ts` | 추가 | 단위 테스트 9개 |
| `src/app/blog/[slug]/page.tsx` | 수정 | MDX 소스 전처리 적용 |

## 검증 결과
- 7개 포스트, 61개 이미지 전부 `loading="lazy"` 적용 확인
- 전체 테스트 379개 통과
- 빌드 성공

## Test plan
- [ ] `npm run build` 성공 확인
- [ ] 빌드된 HTML에서 `<img loading="lazy">` 확인
- [ ] 브라우저 DevTools > Network에서 스크롤 시 이미지 지연 로드 확인
- [ ] 라이트박스 클릭 정상 동작 확인
- [ ] 다크/라이트 테마 전환 정상 동작 확인

Closes #90