### PR TITLE
feat(blog): 블로그 태그 칩 필터 추가

### DIFF
--- a/__tests__/components/BlogFilter.test.tsx
+++ b/__tests__/components/BlogFilter.test.tsx
@@ -52,6 +52,13 @@ jest.mock("next/link", () => {
   };
 });
 
+// Next.js navigation 모킹 (useTagFilter에서 사용)
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/blog",
+}));
+
 describe("BlogFilter", () => {
   const mockPosts: PostMeta[] = [
     {
@@ -148,9 +155,10 @@ describe("BlogFilter", () => {
     it("should display post tags", () => {
       render(<BlogFilter {...defaultProps} />);
 
-      expect(screen.getByText("react")).toBeInTheDocument();
-      expect(screen.getByText("frontend")).toBeInTheDocument();
-      expect(screen.getByText("typescript")).toBeInTheDocument();
+      // 태그 텍스트가 칩과 포스트 카드 양쪽에 표시될 수 있으므로 getAllByText 사용
+      expect(screen.getAllByText("react").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("frontend").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("typescript").length).toBeGreaterThanOrEqual(1);
     });
 
     it("should display formatted date", () => {
@@ -176,6 +184,31 @@ describe("BlogFilter", () => {
 
       const articles = screen.getAllByRole("article");
       expect(articles).toHaveLength(3);
+    });
+  });
+
+  describe("태그 칩 필터", () => {
+    it("should render tag chips when multiple tags exist", () => {
+      render(<BlogFilter {...defaultProps} />);
+
+      // mockPosts의 태그: react, frontend, typescript, 여행, 제주
+      // 5개 태그 → 칩 렌더링됨
+      const buttons = screen.getAllByRole("button");
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should filter posts when tag chip is clicked", () => {
+      render(<BlogFilter {...defaultProps} />);
+
+      // "react" 태그 칩 클릭
+      const reactChip = screen.getAllByRole("button").find(
+        (btn) => btn.textContent?.includes("react") && !btn.textContent?.includes("frontend")
+      );
+      if (reactChip) {
+        fireEvent.click(reactChip);
+        // react 태그를 가진 포스트: react-post만
+        expect(screen.getByText("React 시작하기")).toBeInTheDocument();
+      }
     });
   });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,15 @@
 /* Tailwind v4 레이어 순서 정의 - prose-overrides가 typography보다 높은 우선순위 */
 @layer base, theme, components, prose-overrides, utilities;
 
+/* 스크롤바 숨김 유틸리티 */
+@utility scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Tailwind v4: class 기반 다크 모드 활성화 */
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/src/components/BlogFilter.tsx
+++ b/src/components/BlogFilter.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import type { PostMeta } from "@/types";
 import { useSearch } from "@/hooks/useSearch";
+import { useTagFilter } from "@/hooks/useTagFilter";
 import PostThumbnail from "./PostThumbnail";
 import SearchInput from "./SearchInput";
+import TagChips from "./TagChips";
 import HighlightedText from "./HighlightedText";
 import ScrollReveal from "./ScrollReveal";
 
@@ -19,7 +22,11 @@ export default function BlogFilter({
   selectedCategory,
   selectedSubcategory,
 }: BlogFilterProps) {
-  // 검색 훅 (필터링된 포스트에서 검색)
+  // 태그 필터 훅 (카테고리 필터링된 포스트에서 태그 추출)
+  const { availableTags, selectedTag, filteredPosts: tagFilteredPosts, selectTag } =
+    useTagFilter(posts);
+
+  // 검색 훅 (태그 필터링된 포스트에서 검색)
   const {
     query,
     setQuery,
@@ -27,33 +34,47 @@ export default function BlogFilter({
     resultCount,
     isSearching,
     clearSearch,
-  } = useSearch(posts);
+  } = useSearch(tagFilteredPosts);
 
   // 검색어가 최소 길이 이상인지 확인
   const isSearchActive = query.trim().length >= 2;
 
   // 최종 표시할 포스트
-  const displayPosts = isSearchActive ? results.map((r) => r.post) : posts;
+  const displayPosts = isSearchActive
+    ? results.map((r) => r.post)
+    : tagFilteredPosts;
 
   // 검색 시 사용할 쿼리 (검색 비활성 시 빈 문자열)
   const highlightQuery = isSearchActive ? query : "";
 
-  // 빈 결과 메시지 생성
+  // 빈 결과 메시지 (의존 값 변경 시에만 재계산)
   // React JSX 텍스트 노드로 렌더링되므로 자동 이스케이프됨 (XSS 안전)
-  const getEmptyMessage = () => {
+  const emptyMessage = useMemo(() => {
     if (isSearchActive) {
       const truncatedQuery =
         query.length > 50 ? `${query.slice(0, 50)}...` : query;
       return `'${truncatedQuery}'에 대한 검색 결과가 없습니다.`;
     }
+    if (selectedTag) {
+      return `'${selectedTag}' 태그에 해당하는 포스트가 없습니다.`;
+    }
     if (selectedCategory) {
       return `'${selectedCategory}${selectedSubcategory ? ` > ${selectedSubcategory}` : ""}' 카테고리에 포스트가 없습니다.`;
     }
     return "아직 작성된 포스트가 없습니다.";
-  };
+  }, [isSearchActive, query, selectedTag, selectedCategory, selectedSubcategory]);
 
   return (
     <>
+      {/* 태그 칩 필터 */}
+      <div className="mb-4">
+        <TagChips
+          tags={availableTags}
+          selectedTag={selectedTag}
+          onSelectTag={selectTag}
+        />
+      </div>
+
       {/* 검색 입력 */}
       <div className="mb-6">
         <SearchInput
@@ -138,7 +159,7 @@ export default function BlogFilter({
           ))}
         </div>
       ) : (
-        <p className="text-zinc-600 dark:text-zinc-400">{getEmptyMessage()}</p>
+        <p className="text-zinc-600 dark:text-zinc-400">{emptyMessage}</p>
       )}
     </>
   );

--- a/src/components/TagChips.tsx
+++ b/src/components/TagChips.tsx
@@ -1,0 +1,48 @@
+import type { TagCount } from "@/utils/tag";
+
+interface TagChipsProps {
+  tags: TagCount[];
+  selectedTag: string | null;
+  onSelectTag: (tag: string) => void;
+}
+
+export default function TagChips({
+  tags,
+  selectedTag,
+  onSelectTag,
+}: TagChipsProps) {
+  // 태그가 2개 미만이면 칩 UI 불필요
+  if (tags.length < 2) return null;
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+      {tags.map((tag) => {
+        const isActive = selectedTag === tag.name;
+        return (
+          <button
+            key={tag.name}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onSelectTag(tag.name)}
+            className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+              isActive
+                ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+            }`}
+          >
+            <span>{tag.name}</span>
+            <span
+              className={`${
+                isActive
+                  ? "text-blue-500 dark:text-blue-500"
+                  : "text-zinc-400 dark:text-zinc-500"
+              }`}
+            >
+              {tag.count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/__tests__/TagChips.test.tsx
+++ b/src/components/__tests__/TagChips.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import TagChips from "../TagChips";
+import type { TagCount } from "@/utils/tag";
+
+const mockSelectTag = jest.fn();
+
+const sampleTags: TagCount[] = [
+  { name: "guide", count: 3 },
+  { name: "beginner", count: 2 },
+  { name: "tutorial", count: 1 },
+];
+
+const defaultProps = {
+  tags: sampleTags,
+  selectedTag: null as string | null,
+  onSelectTag: mockSelectTag,
+};
+
+describe("TagChips", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("태그 목록을 칩 형태로 렌더링한다", () => {
+    render(<TagChips {...defaultProps} />);
+
+    expect(screen.getByText("guide")).toBeInTheDocument();
+    expect(screen.getByText("beginner")).toBeInTheDocument();
+    expect(screen.getByText("tutorial")).toBeInTheDocument();
+  });
+
+  it("각 태그 옆에 포스트 수를 표시한다", () => {
+    render(<TagChips {...defaultProps} />);
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("태그 클릭 시 onSelectTag를 호출한다", () => {
+    render(<TagChips {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("guide"));
+    expect(mockSelectTag).toHaveBeenCalledWith("guide");
+  });
+
+  it("선택된 태그에 활성 스타일을 적용한다", () => {
+    render(<TagChips {...defaultProps} selectedTag="guide" />);
+
+    const guideButton = screen.getByText("guide").closest("button");
+    expect(guideButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("선택되지 않은 태그에 비활성 상태를 표시한다", () => {
+    render(<TagChips {...defaultProps} selectedTag="guide" />);
+
+    const beginnerButton = screen.getByText("beginner").closest("button");
+    expect(beginnerButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("빈 태그 목록이면 렌더링하지 않는다", () => {
+    const { container } = render(
+      <TagChips tags={[]} selectedTag={null} onSelectTag={mockSelectTag} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("태그가 1개뿐이면 렌더링하지 않는다", () => {
+    const { container } = render(
+      <TagChips
+        tags={[{ name: "only", count: 1 }]}
+        selectedTag={null}
+        onSelectTag={mockSelectTag}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("접근성: 각 버튼에 aria-pressed 속성이 있다", () => {
+    render(<TagChips {...defaultProps} />);
+
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((button) => {
+      expect(button).toHaveAttribute("aria-pressed");
+    });
+  });
+});

--- a/src/hooks/__tests__/useTagFilter.test.ts
+++ b/src/hooks/__tests__/useTagFilter.test.ts
@@ -1,0 +1,204 @@
+import { renderHook, act } from "@testing-library/react";
+import { useTagFilter } from "../useTagFilter";
+import type { PostMeta } from "@/types";
+
+// Next.js router mock
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/blog",
+}));
+
+const createPost = (overrides: Partial<PostMeta> = {}): PostMeta => ({
+  slug: "test-post",
+  title: "Test Post",
+  date: "2026-01-01",
+  description: "Test description",
+  category: "개발",
+  tags: [],
+  readingTime: "5 min",
+  ...overrides,
+});
+
+const samplePosts: PostMeta[] = [
+  createPost({ slug: "p1", tags: ["guide", "beginner"] }),
+  createPost({ slug: "p2", tags: ["guide", "tutorial"] }),
+  createPost({ slug: "p3", tags: ["beginner"] }),
+  createPost({ slug: "p4", tags: [] }),
+];
+
+describe("useTagFilter", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("초기 상태: 선택된 태그 없음, 전체 포스트 반환", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("사용 가능한 태그 목록을 개수와 함께 반환한다", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    expect(result.current.availableTags).toEqual([
+      { name: "beginner", count: 2 },
+      { name: "guide", count: 2 },
+      { name: "tutorial", count: 1 },
+    ]);
+  });
+
+  it("태그 선택 시 해당 태그 포스트만 필터링한다", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+
+    expect(result.current.selectedTag).toBe("guide");
+    expect(result.current.filteredPosts).toHaveLength(2);
+    expect(result.current.filteredPosts.map((p) => p.slug)).toEqual([
+      "p1",
+      "p2",
+    ]);
+  });
+
+  it("이미 선택된 태그를 다시 클릭하면 선택 해제한다 (토글)", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+    act(() => {
+      result.current.selectTag("guide");
+    });
+
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("다른 태그를 클릭하면 선택이 전환된다", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+    act(() => {
+      result.current.selectTag("tutorial");
+    });
+
+    expect(result.current.selectedTag).toBe("tutorial");
+    expect(result.current.filteredPosts).toHaveLength(1);
+    expect(result.current.filteredPosts[0].slug).toBe("p2");
+  });
+
+  it("clearTag로 선택을 해제한다", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+    act(() => {
+      result.current.clearTag();
+    });
+
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("태그 선택 시 URL에 tag 파라미터를 추가한다", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/blog?tag=guide", {
+      scroll: false,
+    });
+  });
+
+  it("태그 해제 시 URL에서 tag 파라미터를 제거한다", () => {
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+    act(() => {
+      result.current.selectTag("guide");
+    });
+
+    expect(mockPush).toHaveBeenLastCalledWith("/blog", { scroll: false });
+  });
+
+  it("기존 URL 파라미터(category 등)를 보존한다", () => {
+    mockSearchParams = new URLSearchParams("category=개발");
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    act(() => {
+      result.current.selectTag("guide");
+    });
+
+    const pushCall = mockPush.mock.calls[0][0] as string;
+    expect(pushCall).toContain("category=");
+    expect(pushCall).toContain("tag=guide");
+  });
+
+  it("URL에서 초기 태그 파라미터를 읽는다", () => {
+    mockSearchParams = new URLSearchParams("tag=beginner");
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    expect(result.current.selectedTag).toBe("beginner");
+    expect(result.current.filteredPosts).toHaveLength(2);
+  });
+
+  it("URL의 태그가 존재하지 않으면 무시한다", () => {
+    mockSearchParams = new URLSearchParams("tag=nonexistent");
+    const { result } = renderHook(() => useTagFilter(samplePosts));
+
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(4);
+  });
+
+  it("포스트 목록이 변경되면 태그 목록이 재계산된다", () => {
+    const { result, rerender } = renderHook(
+      ({ posts }) => useTagFilter(posts),
+      { initialProps: { posts: samplePosts } }
+    );
+
+    expect(result.current.availableTags).toHaveLength(3);
+
+    // 포스트를 줄임
+    rerender({
+      posts: [createPost({ slug: "p1", tags: ["guide"] })],
+    });
+
+    expect(result.current.availableTags).toHaveLength(1);
+    expect(result.current.availableTags[0].name).toBe("guide");
+  });
+
+  it("선택된 태그가 포스트 변경으로 사라지면 자동 해제된다", () => {
+    const { result, rerender } = renderHook(
+      ({ posts }) => useTagFilter(posts),
+      { initialProps: { posts: samplePosts } }
+    );
+
+    act(() => {
+      result.current.selectTag("tutorial");
+    });
+    expect(result.current.selectedTag).toBe("tutorial");
+
+    // tutorial 태그가 없는 포스트만 남김
+    rerender({
+      posts: [createPost({ slug: "p1", tags: ["guide"] })],
+    });
+
+    expect(result.current.selectedTag).toBeNull();
+    expect(result.current.filteredPosts).toHaveLength(1);
+  });
+});

--- a/src/hooks/useTagFilter.ts
+++ b/src/hooks/useTagFilter.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import type { PostMeta } from "@/types";
+import { extractTagsWithCount, type TagCount } from "@/utils/tag";
+
+export interface UseTagFilterReturn {
+  availableTags: TagCount[];
+  selectedTag: string | null;
+  filteredPosts: PostMeta[];
+  selectTag: (tag: string) => void;
+  clearTag: () => void;
+}
+
+/**
+ * 태그 기반 포스트 필터링 훅.
+ * URL ?tag= 파라미터와 동기화하며, 기존 파라미터(category 등)를 보존한다.
+ */
+export function useTagFilter(posts: PostMeta[]): UseTagFilterReturn {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // 사용 가능한 태그 추출
+  const availableTags = useMemo(() => extractTagsWithCount(posts), [posts]);
+
+  // 태그 유효성 검증: 존재하는 태그만 허용
+  const validTagNames = useMemo(
+    () => new Set(availableTags.map((t) => t.name)),
+    [availableTags]
+  );
+
+  // URL에서 태그 읽기 + 유효성 검증 (useCategoryFilter 패턴 일치)
+  const validatedTag = useMemo(() => {
+    const urlTag = searchParams.get("tag");
+    return urlTag && validTagNames.has(urlTag) ? urlTag : null;
+  }, [searchParams, validTagNames]);
+
+  const [selectedTag, setSelectedTag] = useState<string | null>(validatedTag);
+
+  // URL 파라미터 변경 시 state 동기화 (브라우저 뒤로가기 대응)
+  useEffect(() => {
+    setSelectedTag(validatedTag);
+  }, [validatedTag]);
+
+  // 선택된 태그가 포스트 변경으로 사라지면 자동 해제
+  useEffect(() => {
+    if (selectedTag && !validTagNames.has(selectedTag)) {
+      setSelectedTag(null);
+    }
+  }, [selectedTag, validTagNames]);
+
+  // searchParams를 ref로 보관하여 updateURL의 불필요한 재생성 방지
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
+
+  // URL 업데이트 (기존 파라미터 보존)
+  const updateURL = useCallback(
+    (tag: string | null) => {
+      const params = new URLSearchParams(searchParamsRef.current.toString());
+      if (tag) {
+        params.set("tag", tag);
+      } else {
+        params.delete("tag");
+      }
+      const query = params.toString();
+      router.push(`${pathname}${query ? `?${query}` : ""}`, { scroll: false });
+    },
+    [router, pathname]
+  );
+
+  // 태그 선택/토글
+  const selectTag = useCallback(
+    (tag: string) => {
+      const newTag = selectedTag === tag ? null : tag;
+      setSelectedTag(newTag);
+      updateURL(newTag);
+    },
+    [selectedTag, updateURL]
+  );
+
+  // 태그 클리어
+  const clearTag = useCallback(() => {
+    setSelectedTag(null);
+    updateURL(null);
+  }, [updateURL]);
+
+  // 필터링된 포스트
+  const filteredPosts = useMemo(() => {
+    if (!selectedTag) return posts;
+    return posts.filter((p) => p.tags.includes(selectedTag));
+  }, [posts, selectedTag]);
+
+  return {
+    availableTags,
+    selectedTag,
+    filteredPosts,
+    selectTag,
+    clearTag,
+  };
+}

--- a/src/utils/__tests__/tag.test.ts
+++ b/src/utils/__tests__/tag.test.ts
@@ -1,0 +1,75 @@
+import { extractTagsWithCount, type TagCount } from "../tag";
+import type { PostMeta } from "@/types";
+
+// 테스트용 포스트 팩토리
+function createPost(overrides: Partial<PostMeta> = {}): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-01",
+    description: "Test description",
+    category: "개발",
+    tags: [],
+    readingTime: "5분",
+    ...overrides,
+  };
+}
+
+describe("extractTagsWithCount", () => {
+  it("포스트 배열에서 고유 태그와 각 태그의 포스트 수를 추출한다", () => {
+    const posts = [
+      createPost({ slug: "a", tags: ["guide", "beginner"] }),
+      createPost({ slug: "b", tags: ["guide", "tutorial"] }),
+      createPost({ slug: "c", tags: ["beginner"] }),
+    ];
+
+    const result = extractTagsWithCount(posts);
+
+    expect(result).toEqual<TagCount[]>([
+      { name: "beginner", count: 2 },
+      { name: "guide", count: 2 },
+      { name: "tutorial", count: 1 },
+    ]);
+  });
+
+  it("빈 배열 입력 시 빈 배열을 반환한다", () => {
+    expect(extractTagsWithCount([])).toEqual([]);
+  });
+
+  it("태그가 없는 포스트는 무시한다", () => {
+    const posts = [
+      createPost({ slug: "a", tags: ["guide"] }),
+      createPost({ slug: "b", tags: [] }),
+    ];
+
+    const result = extractTagsWithCount(posts);
+
+    expect(result).toEqual<TagCount[]>([{ name: "guide", count: 1 }]);
+  });
+
+  it("태그 개수 내림차순, 같으면 이름 오름차순으로 정렬한다", () => {
+    const posts = [
+      createPost({ slug: "a", tags: ["zeta", "alpha"] }),
+      createPost({ slug: "b", tags: ["alpha", "beta"] }),
+      createPost({ slug: "c", tags: ["beta"] }),
+    ];
+
+    const result = extractTagsWithCount(posts);
+
+    // alpha: 2, beta: 2, zeta: 1 → 개수 같으면 이름 오름차순
+    expect(result).toEqual<TagCount[]>([
+      { name: "alpha", count: 2 },
+      { name: "beta", count: 2 },
+      { name: "zeta", count: 1 },
+    ]);
+  });
+
+  it("모든 포스트에 태그가 없으면 빈 배열을 반환한다", () => {
+    const posts = [
+      createPost({ slug: "a", tags: [] }),
+      createPost({ slug: "b", tags: [] }),
+    ];
+
+    expect(extractTagsWithCount(posts)).toEqual([]);
+  });
+});

--- a/src/utils/tag.ts
+++ b/src/utils/tag.ts
@@ -1,0 +1,26 @@
+import type { PostMeta } from "@/types";
+
+export interface TagCount {
+  name: string;
+  count: number;
+}
+
+/**
+ * 포스트 배열에서 고유 태그와 각 태그의 포스트 수를 추출한다.
+ * 개수 내림차순, 같으면 이름 오름차순으로 정렬.
+ */
+export function extractTagsWithCount(
+  posts: Pick<PostMeta, "tags">[]
+): TagCount[] {
+  const countMap = new Map<string, number>();
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      countMap.set(tag, (countMap.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(countMap.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## Summary

블로그 페이지에 태그 기반 칩 필터를 추가하여 카테고리 → 태그 → 텍스트 검색 3단계 필터 체인을 구성한다.

Closes #99

## Changes

### 신규 파일
- `src/utils/tag.ts` - `extractTagsWithCount` 유틸리티 (태그 집계/정렬)
- `src/hooks/useTagFilter.ts` - 태그 필터 상태 관리 + URL `?tag=` 동기화 훅
- `src/components/TagChips.tsx` - 태그 칩 UI 컴포넌트

### 수정 파일
- `src/components/BlogFilter.tsx` - TagChips + useTagFilter 통합, 필터 체인 연결
- `src/app/globals.css` - `scrollbar-hide` CSS 유틸리티 추가

### 테스트
- 26개 신규 테스트 추가 (전체 407개 통과)
- `src/utils/__tests__/tag.test.ts` (5개)
- `src/hooks/__tests__/useTagFilter.test.ts` (13개)
- `src/components/__tests__/TagChips.test.tsx` (8개)
- `__tests__/components/BlogFilter.test.tsx` (태그 칩 관련 2개 추가)

## 주요 설계 결정

| 결정 | 근거 |
|------|------|
| 단일 선택 토글 | 현재 포스트 7개, 태그 소수 → 다중 선택은 과잉 |
| 태그 2개 미만 시 미표시 | 칩 UI가 무의미한 경우 제거 |
| URL `?tag=` 동기화 | 기존 `?category=` 파라미터와 공존, 공유/뒤로가기 지원 |
| `useRef`로 searchParams 참조 | `updateURL` 함수 연쇄 재생성 방지 |
| `useMemo`로 emptyMessage | 렌더링 최적화 |

## Code Review

- 보안 이슈: 0건 (URL 파라미터 화이트리스트 검증 적용)
- CRITICAL/HIGH: 0건 (리뷰 피드백 반영 완료)
- 빌드: 성공

## Test Plan

- [x] 블로그 페이지에서 태그 칩 표시 확인
- [x] 칩 클릭 시 해당 태그 포스트만 필터링
- [x] 같은 칩 재클릭 시 필터 해제
- [x] 카테고리 필터 + 태그 칩 + 검색 AND 조합 동작
- [x] URL `?tag=xxx` 파라미터 반영 및 공유 가능
- [x] 브라우저 뒤로가기 시 상태 복원
- [x] 다크/라이트 모드 스타일 정상
- [x] 모바일 가로 스크롤 동작