### PR TITLE
feat(blog): giscus 기반 댓글 기능 추가 (#55)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kmg733.github.io",
       "version": "0.1.0",
       "dependencies": {
+        "@giscus/react": "^3.1.0",
         "@tailwindcss/typography": "^0.5.19",
         "gray-matter": "^4.0.3",
         "next": "16.1.1",
@@ -1344,6 +1345,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2504,6 +2517,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
@@ -3563,6 +3591,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -6676,6 +6710,15 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -9429,6 +9472,37 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@giscus/react": "^3.1.0",
     "@tailwindcss/typography": "^0.5.19",
     "gray-matter": "^4.0.3",
     "next": "16.1.1",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -15,6 +15,7 @@ import PostNavigation from "@/components/PostNavigation";
 import CodeBlock from "@/components/CodeBlock";
 import BackButton from "@/components/BackButton";
 import { GlossaryProvider, GlossarySection, Term } from "@/components/glossary";
+import GiscusComments from "@/components/GiscusComments";
 import type { Metadata } from "next";
 
 const prettyCodeOptions: PrettyCodeOptions = {
@@ -147,6 +148,7 @@ export default async function BlogPostPage({ params }: Props) {
             next={adjacentPosts.next}
           />
           <RelatedPosts posts={relatedPosts} />
+          {post.comments !== false && <GiscusComments />}
         </article>
 
         {/* 우측 목차 영역 */}

--- a/src/components/GiscusComments.tsx
+++ b/src/components/GiscusComments.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Giscus from "@giscus/react";
+import { useTheme } from "@/hooks/useTheme";
+import { GISCUS_CONFIG } from "@/lib/giscus-config";
+
+export default function GiscusComments() {
+  const theme = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <section className="mt-16">
+      <hr className="mb-8 border-zinc-200 dark:border-zinc-700" />
+      <Giscus
+        {...GISCUS_CONFIG}
+        theme={theme === "dark" ? "dark_dimmed" : "light"}
+      />
+    </section>
+  );
+}

--- a/src/components/__tests__/GiscusComments.test.tsx
+++ b/src/components/__tests__/GiscusComments.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import GiscusComments from "../GiscusComments";
+
+// @giscus/react 모킹
+jest.mock("@giscus/react", () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => (
+    <div data-testid="giscus-widget" data-theme={props.theme as string} />
+  ),
+}));
+
+// useTheme 훅 모킹
+let mockTheme: "light" | "dark" = "light";
+jest.mock("@/hooks/useTheme", () => ({
+  useTheme: () => mockTheme,
+}));
+
+describe("GiscusComments", () => {
+  beforeEach(() => {
+    mockTheme = "light";
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 1. 렌더링
+  // ─────────────────────────────────────────────────────
+  describe("렌더링", () => {
+    test("giscus 위젯이 렌더링된다", () => {
+      render(<GiscusComments />);
+
+      expect(screen.getByTestId("giscus-widget")).toBeInTheDocument();
+    });
+
+    test("댓글 섹션 구분선이 표시된다", () => {
+      const { container } = render(<GiscusComments />);
+
+      expect(container.querySelector("hr")).toBeInTheDocument();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 테마 연동
+  // ─────────────────────────────────────────────────────
+  describe("테마 연동", () => {
+    test("light 모드에서 light 테마가 전달된다", () => {
+      mockTheme = "light";
+
+      render(<GiscusComments />);
+
+      expect(screen.getByTestId("giscus-widget")).toHaveAttribute(
+        "data-theme",
+        "light"
+      );
+    });
+
+    test("dark 모드에서 dark_dimmed 테마가 전달된다", () => {
+      mockTheme = "dark";
+
+      render(<GiscusComments />);
+
+      expect(screen.getByTestId("giscus-widget")).toHaveAttribute(
+        "data-theme",
+        "dark_dimmed"
+      );
+    });
+  });
+});

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,100 @@
+import { renderHook, act } from "@testing-library/react";
+import { useTheme } from "../useTheme";
+
+describe("useTheme", () => {
+  let mockObserverInstance: {
+    observe: jest.Mock;
+    disconnect: jest.Mock;
+    callback: MutationCallback | null;
+  };
+
+  beforeEach(() => {
+    mockObserverInstance = {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+      callback: null,
+    };
+
+    global.MutationObserver = jest.fn((callback: MutationCallback) => {
+      mockObserverInstance.callback = callback;
+      return mockObserverInstance as unknown as MutationObserver;
+    });
+
+    // 기본: light 모드
+    document.documentElement.classList.remove("dark");
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 1. 초기 상태
+  // ─────────────────────────────────────────────────────
+  describe("초기 상태", () => {
+    test("dark 클래스가 없으면 'light'를 반환한다", () => {
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current).toBe("light");
+    });
+
+    test("dark 클래스가 있으면 'dark'를 반환한다", () => {
+      document.documentElement.classList.add("dark");
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current).toBe("dark");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 2. 테마 변경 감지
+  // ─────────────────────────────────────────────────────
+  describe("테마 변경 감지", () => {
+    test("dark 클래스가 추가되면 'dark'로 변경된다", () => {
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current).toBe("light");
+
+      act(() => {
+        document.documentElement.classList.add("dark");
+        mockObserverInstance.callback?.([], {} as MutationObserver);
+      });
+
+      expect(result.current).toBe("dark");
+    });
+
+    test("dark 클래스가 제거되면 'light'로 변경된다", () => {
+      document.documentElement.classList.add("dark");
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current).toBe("dark");
+
+      act(() => {
+        document.documentElement.classList.remove("dark");
+        mockObserverInstance.callback?.([], {} as MutationObserver);
+      });
+
+      expect(result.current).toBe("light");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────
+  // 3. MutationObserver 설정
+  // ─────────────────────────────────────────────────────
+  describe("MutationObserver 설정", () => {
+    test("document.documentElement를 관찰한다", () => {
+      renderHook(() => useTheme());
+
+      expect(mockObserverInstance.observe).toHaveBeenCalledWith(
+        document.documentElement,
+        { attributes: true, attributeFilter: ["class"] }
+      );
+    });
+
+    test("언마운트 시 observer를 disconnect한다", () => {
+      const { unmount } = renderHook(() => useTheme());
+
+      unmount();
+
+      expect(mockObserverInstance.disconnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 현재 테마를 감지하는 커스텀 훅
+ *
+ * document.documentElement의 'dark' 클래스 유무를 MutationObserver로 감지하여
+ * 현재 테마 상태를 반환한다. ThemeToggle 컴포넌트 수정 없이 테마 상태를 읽을 수 있다.
+ */
+export function useTheme(): "light" | "dark" {
+  const [theme, setTheme] = useState<"light" | "dark">(() =>
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+      ? "dark"
+      : "light"
+  );
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const isDark = document.documentElement.classList.contains("dark");
+      setTheme(isDark ? "dark" : "light");
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}

--- a/src/lib/giscus-config.ts
+++ b/src/lib/giscus-config.ts
@@ -1,0 +1,20 @@
+import type { GiscusProps } from "@giscus/react";
+
+/**
+ * Giscus 댓글 시스템 설정
+ *
+ * repoId: GitHub GraphQL API에서 확인
+ * category/categoryId: https://giscus.app 에서 설정 후 확인
+ */
+export const GISCUS_CONFIG: Omit<GiscusProps, "theme"> = {
+  repo: "kmg733/kmg733.github.io",
+  repoId: "MDEwOlJlcG9zaXRvcnk0MDE4MTc5ODc=",
+  category: "Comments",
+  categoryId: "DIC_kwDOF_NBg84C51la",
+  mapping: "pathname",
+  strict: "0",
+  reactionsEnabled: "1",
+  emitMetadata: "0",
+  inputPosition: "bottom",
+  lang: "ko",
+} as const;

--- a/src/repositories/file-post.repository.ts
+++ b/src/repositories/file-post.repository.ts
@@ -134,6 +134,7 @@ export class FilePostRepository implements IPostRepository {
       ...(frontmatter.relatedSlugs &&
         frontmatter.relatedSlugs.length > 0 &&
         this.buildRelatedSlugs(frontmatter.relatedSlugs)),
+      ...(frontmatter.comments === false && { comments: false }),
     };
   }
 

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -14,6 +14,7 @@ export interface PostMeta {
   series?: string;
   seriesOrder?: number;
   relatedSlugs?: string[];
+  comments?: boolean;
 }
 
 /**
@@ -46,4 +47,5 @@ export interface PostFrontmatter {
   series?: string;
   seriesOrder?: number;
   relatedSlugs?: string[];
+  comments?: boolean;
 }


### PR DESCRIPTION
## Summary
- GitHub Discussions 기반 **giscus** 댓글 시스템을 블로그 포스트에 통합
- 다크/라이트 모드 테마 자동 연동 (`useTheme` 훅 + MutationObserver)
- front matter `comments: false`로 포스트별 댓글 비활성화 지원

## 변경 사항

### 신규 파일
| 파일 | 설명 |
|------|------|
| `src/components/GiscusComments.tsx` | giscus 댓글 컴포넌트 |
| `src/hooks/useTheme.ts` | MutationObserver 기반 테마 감지 훅 |
| `src/lib/giscus-config.ts` | giscus 설정 상수 |
| `src/components/__tests__/GiscusComments.test.tsx` | 컴포넌트 테스트 (4개) |
| `src/hooks/__tests__/useTheme.test.ts` | 훅 테스트 (6개) |

### 수정 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/types/post.ts` | `comments?: boolean` 필드 추가 |
| `src/repositories/file-post.repository.ts` | `comments` front matter 파싱 |
| `src/app/blog/[slug]/page.tsx` | GiscusComments 컴포넌트 통합 |

## Test plan
- [x] 전체 테스트 423개 통과
- [x] 빌드 성공 (Next.js 정적 빌드)
- [x] 다크/라이트 모드 전환 시 giscus 테마 동기화 확인
- [x] 모바일 환경 댓글 UI 확인
- [x] `comments: false` front matter 설정 시 댓글 미표시 확인

Closes #55