### PR TITLE
feat: 메인 페이지에 추천글 섹션 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,10 +8,12 @@ import FloatingParticles from "@/components/FloatingParticles";
 import BlogStats from "@/components/BlogStats";
 import GradientOrbs from "@/components/GradientOrbs";
 import TechStackSection from "@/components/TechStackSection";
+import FeaturedPostsSection from "@/components/FeaturedPostsSection";
 
 export default function Home() {
   const recentPosts = postService.getRecentPosts(HOME_DEFAULTS.RECENT_POSTS_COUNT);
   const allPosts = postService.getAllPosts();
+  const featuredPosts = postService.getFeaturedPosts(HOME_DEFAULTS.FEATURED_POSTS_COUNT);
 
   // 블로그 통계 계산
   const totalPosts = allPosts.length;
@@ -87,7 +89,13 @@ export default function Home() {
         />
       </ScrollReveal>
 
-      {/* Divider: BlogStats ↔ Recent Posts */}
+      {/* Divider: BlogStats ↔ Featured Posts */}
+      <hr className="my-12 h-px border-none bg-gradient-to-r from-transparent via-amber-300/50 to-transparent dark:via-slate-600/50" />
+
+      {/* Featured Posts by Subcategory */}
+      <FeaturedPostsSection posts={featuredPosts} />
+
+      {/* Divider: Featured Posts ↔ Recent Posts */}
       <hr className="my-12 h-px border-none bg-gradient-to-r from-transparent via-amber-300/50 to-transparent dark:via-slate-600/50" />
 
       {/* Recent Posts */}

--- a/src/components/FeaturedPostCard.tsx
+++ b/src/components/FeaturedPostCard.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import PostThumbnail from "@/components/PostThumbnail";
+import { DATE_FORMAT } from "@/lib/constants";
+import type { PostMeta } from "@/types";
+
+interface FeaturedPostCardProps {
+  post: PostMeta;
+}
+
+export default function FeaturedPostCard({ post }: FeaturedPostCardProps) {
+  return (
+    <article className="card-hover-accent group overflow-hidden rounded-md border border-zinc-200 transition-colors hover:border-zinc-300 dark:border-zinc-800 dark:hover:border-zinc-700">
+      <Link href={`/blog/${post.slug}`} className="flex flex-row items-center gap-3 p-2.5">
+        <div className="h-16 w-16 shrink-0 overflow-hidden rounded bg-zinc-100 dark:bg-zinc-800">
+          <PostThumbnail thumbnail={post.thumbnail} alt={post.title} />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <h3 className="line-clamp-1 text-sm font-semibold leading-snug group-hover:text-blue-600 dark:group-hover:text-blue-400">
+            {post.title}
+          </h3>
+          <p className="line-clamp-1 text-xs text-zinc-500 dark:text-zinc-400">
+            {post.description}
+          </p>
+          <div className="mt-1 flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
+            <time dateTime={post.date}>
+              {new Date(post.date).toLocaleDateString(
+                DATE_FORMAT.LOCALE,
+                DATE_FORMAT.OPTIONS
+              )}
+            </time>
+            <span>{post.readingTime}</span>
+          </div>
+        </div>
+      </Link>
+    </article>
+  );
+}

--- a/src/components/FeaturedPostsSection.tsx
+++ b/src/components/FeaturedPostsSection.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import ScrollReveal from "@/components/ScrollReveal";
+import FeaturedPostCard from "@/components/FeaturedPostCard";
+import type { PostMeta } from "@/types";
+
+interface FeaturedPostsSectionProps {
+  posts: PostMeta[];
+}
+
+export default function FeaturedPostsSection({
+  posts,
+}: FeaturedPostsSectionProps) {
+  if (posts.length === 0) return null;
+
+  return (
+    <section>
+      <ScrollReveal direction="fade">
+        <div className="mb-6 flex items-center justify-between">
+          <h2 className="text-2xl font-bold">추천글</h2>
+          <Link
+            href="/blog"
+            className="text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+          >
+            모든 글 보기 →
+          </Link>
+        </div>
+      </ScrollReveal>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {posts.map((post, index) => (
+          <ScrollReveal key={post.slug} direction="up" index={index} staggerDelay={80}>
+            <FeaturedPostCard post={post} />
+          </ScrollReveal>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,6 +19,7 @@ export const THUMBNAIL_DEFAULTS = {
 // 홈페이지 관련 상수
 export const HOME_DEFAULTS = {
   RECENT_POSTS_COUNT: 3,
+  FEATURED_POSTS_COUNT: 5,
 } as const;
 
 // 날짜 포맷 관련 상수

--- a/src/services/__tests__/post.service.featured.test.ts
+++ b/src/services/__tests__/post.service.featured.test.ts
@@ -1,0 +1,102 @@
+import { PostService } from "../post.service";
+import type { IPostRepository } from "@/interfaces";
+import type { PostMeta } from "@/types";
+
+function createPostMeta(overrides: Partial<PostMeta> = {}): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-01",
+    description: "Test description",
+    category: "dev",
+    tags: ["javascript"],
+    readingTime: "5 min read",
+    ...overrides,
+  };
+}
+
+describe("PostService.getFeaturedPosts", () => {
+  let mockRepository: jest.Mocked<IPostRepository>;
+  let service: PostService;
+
+  beforeEach(() => {
+    mockRepository = {
+      findAll: jest.fn(),
+      findBySlug: jest.fn(),
+      findAllSlugs: jest.fn(),
+    };
+    service = new PostService(mockRepository);
+  });
+
+  it("각 서브카테고리에서 최신 1개씩 선별한다", () => {
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-new", subcategory: "JavaScript", date: "2025-06-01" }),
+      createPostMeta({ slug: "js-old", subcategory: "JavaScript", date: "2025-01-01" }),
+      createPostMeta({ slug: "java-new", subcategory: "Java", date: "2025-05-01" }),
+      createPostMeta({ slug: "java-old", subcategory: "Java", date: "2025-02-01" }),
+    ];
+
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getFeaturedPosts(5);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((p) => p.slug)).toContain("js-new");
+    expect(result.map((p) => p.slug)).toContain("java-new");
+    expect(result.map((p) => p.slug)).not.toContain("js-old");
+  });
+
+  it("포스트 수가 많은 서브카테고리가 우선 선택된다", () => {
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "java-1", subcategory: "Java", date: "2025-06-01" }),
+      createPostMeta({ slug: "java-2", subcategory: "Java", date: "2025-05-01" }),
+      createPostMeta({ slug: "java-3", subcategory: "Java", date: "2025-04-01" }),
+      createPostMeta({ slug: "js-1", subcategory: "JavaScript", date: "2025-06-01" }),
+      createPostMeta({ slug: "web-1", subcategory: "웹", date: "2025-06-01" }),
+    ];
+
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getFeaturedPosts(2);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].slug).toBe("java-1");
+  });
+
+  it("count 이하로 반환한다", () => {
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "js-1", subcategory: "JavaScript", date: "2025-06-01" }),
+      createPostMeta({ slug: "java-1", subcategory: "Java", date: "2025-05-01" }),
+      createPostMeta({ slug: "web-1", subcategory: "웹", date: "2025-04-01" }),
+      createPostMeta({ slug: "db-1", subcategory: "Database", date: "2025-03-01" }),
+    ];
+
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getFeaturedPosts(2);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("subcategory가 없는 포스트는 제외된다", () => {
+    const allPosts: PostMeta[] = [
+      createPostMeta({ slug: "no-sub", date: "2025-06-01" }),
+      createPostMeta({ slug: "js-1", subcategory: "JavaScript", date: "2025-05-01" }),
+    ];
+
+    mockRepository.findAll.mockReturnValue(allPosts);
+
+    const result = service.getFeaturedPosts(5);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].slug).toBe("js-1");
+  });
+
+  it("포스트가 없으면 빈 배열을 반환한다", () => {
+    mockRepository.findAll.mockReturnValue([]);
+
+    const result = service.getFeaturedPosts(5);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -58,6 +58,33 @@ export class PostService {
   }
 
   /**
+   * 서브카테고리별 대표 포스트를 선별하여 반환합니다.
+   * 각 서브카테고리에서 최신 1개씩, 포스트 수가 많은 카테고리 우선.
+   */
+  getFeaturedPosts(count: number): PostMeta[] {
+    const allPosts = this.postRepository.findAll();
+
+    const grouped = new Map<string, PostMeta[]>();
+    for (const post of allPosts) {
+      if (!post.subcategory) continue;
+      const existing = grouped.get(post.subcategory) ?? [];
+      existing.push(post);
+      grouped.set(post.subcategory, existing);
+    }
+
+    return Array.from(grouped.entries())
+      .map(([, posts]) => {
+        const sorted = [...posts].sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+        );
+        return { latest: sorted[0], totalCount: posts.length };
+      })
+      .sort((a, b) => b.totalCount - a.totalCount)
+      .slice(0, count)
+      .map((g) => g.latest);
+  }
+
+  /**
    * 관련 포스트를 조회합니다.
    * frontmatter의 relatedSlugs로 수동 지정된 글을 우선 반환하고,
    * 남은 슬롯을 같은 subcategory 내 tags 기반 자동 추천으로 채웁니다.


### PR DESCRIPTION
## Summary

- 메인 페이지에 서브카테고리별 대표 포스트 5개를 선별하여 추천글 섹션 추가
- `PostService.getFeaturedPosts()` 메서드로 카테고리 다양성 보장 (포스트 많은 카테고리 우선)
- BlogStats와 최근 포스트 사이에 컴팩트한 카드 UI로 배치

## Changes

| 파일 | 변경 |
|------|------|
| `src/services/post.service.ts` | `getFeaturedPosts()` 메서드 추가 |
| `src/lib/constants.ts` | `FEATURED_POSTS_COUNT: 5` 상수 추가 |
| `src/components/FeaturedPostCard.tsx` | 컴팩트 포스트 카드 컴포넌트 (신규) |
| `src/components/FeaturedPostsSection.tsx` | 추천글 섹션 컨테이너 (신규) |
| `src/app/page.tsx` | 메인 페이지에 추천글 섹션 통합 |
| `src/services/__tests__/post.service.featured.test.ts` | 단위 테스트 5개 (신규) |

## Test plan

- [x] `getFeaturedPosts()` 단위 테스트 5개 통과
- [x] `npx next build` SSG 빌드 성공
- [x] 다크/라이트 모드 UI 확인
- [x] 기존 테스트 430개 영향 없음

Closes #73