### PR TITLE
feat(blog): 포스트 이미지 갤러리 UI 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1663,6 +1663,75 @@ body::before {
     user-select: none;
   }
 
+  /* 썸네일 필름스트립 (하단 가로, 카운터 위에 위치) */
+  .lightbox-filmstrip {
+    position: absolute;
+    left: 50%;
+    bottom: 3.75rem;
+    transform: translateX(-50%);
+    z-index: 10;
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    max-width: min(92vw, 56rem);
+    padding: 0.5rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    background-color: rgba(0, 0, 0, 0.35);
+    border-radius: 0.75rem;
+    scrollbar-width: thin;
+  }
+
+  .dark .lightbox-filmstrip {
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+
+  /* 필름스트립이 있을 때만 메인 이미지 높이를 줄여 겹침 방지 (단일 이미지는 영향 없음) */
+  .lightbox-overlay:has(.lightbox-filmstrip) .lightbox-content {
+    max-height: calc(90vh - 7rem);
+  }
+
+  .lightbox-thumb {
+    flex: 0 0 auto;
+    width: 4.5rem;
+    height: 3.25rem;
+    padding: 0;
+    background: none;
+    border: 2px solid transparent;
+    border-radius: 0.375rem;
+    overflow: hidden;
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.2s ease, border-color 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .lightbox-thumb img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .lightbox-thumb:hover {
+    opacity: 0.85;
+  }
+
+  .lightbox-thumb.active {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.9);
+  }
+
+  .lightbox-thumb:focus {
+    outline: none;
+  }
+
+  .lightbox-thumb:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+    opacity: 1;
+  }
+
   /* 모바일 반응형 */
   @media (max-width: 640px) {
     .lightbox-prev,
@@ -1682,6 +1751,16 @@ body::before {
     .lightbox-counter {
       bottom: 0.75rem;
       font-size: 0.8rem;
+    }
+
+    /* 필름스트립: 모바일에서는 카운터 위치에 맞춰 낮추고 썸네일 축소 */
+    .lightbox-filmstrip {
+      bottom: 3.25rem;
+    }
+
+    .lightbox-thumb {
+      width: 3.5rem;
+      height: 2.5rem;
     }
   }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1592,6 +1592,99 @@ body::before {
     border-top-color: #94a3b8;
   }
 
+  /* 갤러리 좌우 네비게이션 버튼 */
+  .lightbox-prev,
+  .lightbox-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    padding: 0;
+    background-color: rgba(255, 255, 255, 0.1);
+    border: none;
+    border-radius: 50%;
+    color: white;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s ease,
+      opacity 0.2s ease;
+  }
+
+  .lightbox-prev {
+    left: 1rem;
+  }
+
+  .lightbox-next {
+    right: 1rem;
+  }
+
+  .lightbox-prev:hover:not(:disabled),
+  .lightbox-next:hover:not(:disabled) {
+    background-color: rgba(255, 255, 255, 0.2);
+    transform: translateY(-50%) scale(1.1);
+  }
+
+  .lightbox-prev:focus,
+  .lightbox-next:focus {
+    outline: none;
+  }
+
+  .lightbox-prev:focus-visible,
+  .lightbox-next:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+
+  .lightbox-prev:disabled,
+  .lightbox-next:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  /* 위치 인디케이터 (3 / 7) */
+  .lightbox-counter {
+    position: absolute;
+    bottom: 1.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    padding: 0.35rem 0.85rem;
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 9999px;
+    color: rgba(255, 255, 255, 0.95);
+    font-size: 0.875rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.03em;
+    user-select: none;
+  }
+
+  /* 모바일 반응형 */
+  @media (max-width: 640px) {
+    .lightbox-prev,
+    .lightbox-next {
+      width: 2.5rem;
+      height: 2.5rem;
+    }
+
+    .lightbox-prev {
+      left: 0.5rem;
+    }
+
+    .lightbox-next {
+      right: 0.5rem;
+    }
+
+    .lightbox-counter {
+      bottom: 0.75rem;
+      font-size: 0.8rem;
+    }
+  }
+
   /* 닫기 애니메이션 */
   .lightbox-overlay.closing {
     animation: lightbox-fade-out 0.25s ease-out forwards;

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,16 +1,29 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useTheme } from "@/hooks/useTheme";
+import { useSwipe } from "@/hooks/useSwipe";
+import { collectGalleryAt, type GalleryImage } from "@/utils/galleryImages";
 
 export default function ImageLightbox() {
   const [isOpen, setIsOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const [imageAlt, setImageAlt] = useState("");
+  const [images, setImages] = useState<GalleryImage[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const [mounted, setMounted] = useState(false);
+
+  // 클릭 시점의 현재 테마를 읽기 위한 ref (이벤트 핸들러는 1회 등록되어 stale 클로저 방지)
+  // useFocusTrap / useKeyboardShortcut 와 동일한 렌더 중 ref 동기화 관용구를 따른다.
+  const theme = useTheme();
+  const themeRef = useRef(theme);
+  themeRef.current = theme;
+
+  const currentImage = images[currentIndex] ?? null;
+  const total = images.length;
+  const hasMultiple = total > 1;
 
   // Hydration 완료 후 마운트
   useEffect(() => {
@@ -22,6 +35,26 @@ export default function ImageLightbox() {
     if (isClosing) return; // 이미 닫기 중이면 무시
     setIsClosing(true);
   }, [isClosing]);
+
+  // 이전/다음 이미지로 이동 (clamp: 경계에서 정지)
+  // 실제 이동이 발생할 때만 로딩 상태를 리셋해 경계에서 스피너가 멈추지 않게 한다.
+  const goPrev = useCallback(() => {
+    if (currentIndex <= 0) return;
+    setIsLoading(true);
+    setCurrentIndex(currentIndex - 1);
+  }, [currentIndex]);
+
+  const goNext = useCallback(() => {
+    if (currentIndex >= total - 1) return;
+    setIsLoading(true);
+    setCurrentIndex(currentIndex + 1);
+  }, [currentIndex, total]);
+
+  // 모바일 터치 스와이프 (왼쪽 → 다음, 오른쪽 → 이전)
+  const swipeHandlers = useSwipe({
+    onSwipeLeft: goNext,
+    onSwipeRight: goPrev,
+  });
 
   // 포커스 트랩 훅 연결
   const { containerRef } = useFocusTrap({
@@ -35,8 +68,8 @@ export default function ImageLightbox() {
       // 닫기 애니메이션(lightbox-fade-out)일 때만 처리
       if (e.animationName === "lightbox-fade-out") {
         setIsOpen(false);
-        setImageSrc(null);
-        setImageAlt("");
+        setImages([]);
+        setCurrentIndex(0);
         setIsClosing(false);
         setIsLoading(true); // 다음 열기를 위해 로딩 상태 리셋
       }
@@ -47,6 +80,15 @@ export default function ImageLightbox() {
   // 이미지 로딩 완료 핸들러
   const handleImageLoad = useCallback(() => {
     setIsLoading(false);
+  }, []);
+
+  // 캐시된 이미지는 마운트 시점에 이미 complete=true 이고 onLoad가
+  // 발화하지 않을 수 있어, 스피너가 멈추지 않는 문제를 방지한다.
+  // key={src}로 이미지 전환 시 재마운트되어 매 이미지마다 1회 실행된다.
+  const imageRef = useCallback((node: HTMLImageElement | null) => {
+    if (node?.complete) {
+      setIsLoading(false);
+    }
   }, []);
 
   // 이미지 로딩 실패 핸들러
@@ -65,6 +107,24 @@ export default function ImageLightbox() {
     };
   }, [isOpen]);
 
+  // 좌우 화살표 키 네비게이션 (ESC/Tab은 useFocusTrap이 담당)
+  useEffect(() => {
+    if (!isOpen || isClosing) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        goNext();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isClosing, goPrev, goNext]);
+
   // 이미지 클릭 이벤트 위임
   useEffect(() => {
     const handleImageClick = (e: MouseEvent) => {
@@ -77,6 +137,8 @@ export default function ImageLightbox() {
         !target.closest(".lightbox-overlay")
       ) {
         const img = target as HTMLImageElement;
+        const prose = img.closest(".prose") as HTMLElement;
+        const currentTheme = themeRef.current;
 
         // 포커스 복원을 위해 클릭된 이미지를 포커스 가능하게 만들고 포커스
         if (img.tabIndex < 0) {
@@ -84,8 +146,14 @@ export default function ImageLightbox() {
         }
         img.focus();
 
-        setImageSrc(img.src);
-        setImageAlt(img.alt || "");
+        const { images: collected, startIndex } = collectGalleryAt(
+          prose,
+          currentTheme,
+          img
+        );
+
+        setImages(collected);
+        setCurrentIndex(startIndex >= 0 ? startIndex : 0);
         setIsLoading(true); // 라이트박스 열 때 로딩 상태 초기화
         setIsOpen(true);
       }
@@ -96,7 +164,7 @@ export default function ImageLightbox() {
   }, []);
 
   // 서버 렌더링 시 또는 닫혀있을 때 렌더링하지 않음
-  if (!mounted || !isOpen || !imageSrc) {
+  if (!mounted || !isOpen || !currentImage) {
     return null;
   }
 
@@ -108,7 +176,7 @@ export default function ImageLightbox() {
       onAnimationEnd={handleAnimationEnd}
       role="dialog"
       aria-modal="true"
-      aria-label={imageAlt || "확대된 이미지"}
+      aria-label={currentImage.alt || "확대된 이미지"}
     >
       {/* 닫기 버튼 */}
       <button
@@ -133,10 +201,41 @@ export default function ImageLightbox() {
         </svg>
       </button>
 
+      {/* 이전 버튼 (이미지 2개 이상일 때만) */}
+      {hasMultiple && (
+        <button
+          className="lightbox-prev"
+          onClick={(e) => {
+            e.stopPropagation();
+            goPrev();
+          }}
+          disabled={currentIndex === 0}
+          aria-label="이전 이미지"
+          type="button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="28"
+            height="28"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+      )}
+
       {/* 확대된 이미지 */}
       <div
         className={`lightbox-content${isClosing ? " closing" : ""}`}
         onClick={(e) => e.stopPropagation()}
+        onTouchStart={swipeHandlers.onTouchStart}
+        onTouchEnd={swipeHandlers.onTouchEnd}
+        onTouchCancel={swipeHandlers.onTouchCancel}
       >
         {/* 로딩 스피너 */}
         {isLoading && (
@@ -147,14 +246,52 @@ export default function ImageLightbox() {
           />
         )}
         <img
-          src={imageSrc}
-          alt={imageAlt}
+          key={currentImage.src}
+          ref={imageRef}
+          src={currentImage.src}
+          alt={currentImage.alt}
           className={`lightbox-image${isLoading ? " loading" : " loaded"}`}
           onClick={closeLightbox}
           onLoad={handleImageLoad}
           onError={handleImageError}
         />
       </div>
+
+      {/* 다음 버튼 (이미지 2개 이상일 때만) */}
+      {hasMultiple && (
+        <button
+          className="lightbox-next"
+          onClick={(e) => {
+            e.stopPropagation();
+            goNext();
+          }}
+          disabled={currentIndex === total - 1}
+          aria-label="다음 이미지"
+          type="button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="28"
+            height="28"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
+      )}
+
+      {/* 위치 인디케이터 (이미지 2개 이상일 때만) */}
+      {/* role="status"가 aria-live="polite"와 aria-atomic을 암묵 포함하므로 중복 선언하지 않는다 */}
+      {hasMultiple && (
+        <div className="lightbox-counter" role="status">
+          {currentIndex + 1} / {total}
+        </div>
+      )}
     </div>,
     document.body
   );

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -36,19 +36,21 @@ export default function ImageLightbox() {
     setIsClosing(true);
   }, [isClosing]);
 
-  // 이전/다음 이미지로 이동 (clamp: 경계에서 정지)
-  // 실제 이동이 발생할 때만 로딩 상태를 리셋해 경계에서 스피너가 멈추지 않게 한다.
-  const goPrev = useCallback(() => {
-    if (currentIndex <= 0) return;
-    setIsLoading(true);
-    setCurrentIndex(currentIndex - 1);
-  }, [currentIndex]);
+  // 특정 인덱스로 이동 (clamp: 범위 밖/동일 인덱스는 no-op)
+  // 실제 이동이 발생할 때만 로딩 상태를 리셋해 경계/동일 이미지에서 스피너가 멈추지 않게 한다.
+  const goTo = useCallback(
+    (index: number) => {
+      if (index < 0 || index >= total) return;
+      if (index === currentIndex) return;
+      setIsLoading(true);
+      setCurrentIndex(index);
+    },
+    [currentIndex, total]
+  );
 
-  const goNext = useCallback(() => {
-    if (currentIndex >= total - 1) return;
-    setIsLoading(true);
-    setCurrentIndex(currentIndex + 1);
-  }, [currentIndex, total]);
+  // 이전/다음 이미지로 이동
+  const goPrev = useCallback(() => goTo(currentIndex - 1), [goTo, currentIndex]);
+  const goNext = useCallback(() => goTo(currentIndex + 1), [goTo, currentIndex]);
 
   // 모바일 터치 스와이프 (왼쪽 → 다음, 오른쪽 → 이전)
   const swipeHandlers = useSwipe({
@@ -91,6 +93,9 @@ export default function ImageLightbox() {
     }
   }, []);
 
+  // 현재 활성 썸네일 (currentIndex 변경 시 화면 안으로 스크롤)
+  const activeThumbRef = useRef<HTMLButtonElement | null>(null);
+
   // 이미지 로딩 실패 핸들러
   const handleImageError = useCallback(() => {
     setIsLoading(false);
@@ -124,6 +129,16 @@ export default function ImageLightbox() {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, isClosing, goPrev, goNext]);
+
+  // 활성 썸네일을 필름스트립 안에서 보이도록 스크롤 (세로/가로 모두 대응)
+  // scrollIntoView 미지원 환경(SSR/구형/jsdom)에서는 옵셔널 체이닝으로 안전하게 생략
+  useEffect(() => {
+    if (!isOpen) return;
+    activeThumbRef.current?.scrollIntoView?.({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [currentIndex, isOpen]);
 
   // 이미지 클릭 이벤트 위임
   useEffect(() => {
@@ -290,6 +305,37 @@ export default function ImageLightbox() {
       {hasMultiple && (
         <div className="lightbox-counter" role="status">
           {currentIndex + 1} / {total}
+        </div>
+      )}
+
+      {/* 썸네일 필름스트립 (이미지 2개 이상일 때만) */}
+      {/* 닫기 버튼 뒤(DOM 마지막)에 배치해 자동 첫 포커스 대상이 닫기 버튼으로 유지된다 */}
+      {hasMultiple && (
+        <div
+          className="lightbox-filmstrip"
+          role="group"
+          aria-label="이미지 목록"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {images.map((img, i) => {
+            const isActive = i === currentIndex;
+            return (
+              <button
+                key={`${i}-${img.src}`}
+                ref={isActive ? activeThumbRef : null}
+                className={`lightbox-thumb${isActive ? " active" : ""}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  goTo(i);
+                }}
+                aria-label={`${i + 1}번째 이미지 보기`}
+                aria-current={isActive ? "true" : undefined}
+                type="button"
+              >
+                <img src={img.src} alt="" loading="lazy" />
+              </button>
+            );
+          })}
         </div>
       )}
     </div>,

--- a/src/components/__tests__/ImageLightboxFilmstrip.test.tsx
+++ b/src/components/__tests__/ImageLightboxFilmstrip.test.tsx
@@ -1,0 +1,222 @@
+import { render, screen, act, fireEvent, within } from "@testing-library/react";
+import ImageLightbox from "../ImageLightbox";
+
+/**
+ * ImageLightbox 썸네일 필름스트립 테스트.
+ *
+ * 갤러리가 열리면 포스트 내 모든 이미지를 작은 썸네일 목록으로 표시하고,
+ * 썸네일 클릭 시 해당 이미지로 이동한다. 활성 썸네일은 강조 + scrollIntoView.
+ * 단일 이미지일 때는 필름스트립을 표시하지 않는다.
+ */
+
+// jsdom은 scrollIntoView를 구현하지 않으므로 모킹한다.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  document.body.style.overflow = "";
+});
+
+/** 테마쌍 figure를 포함한 .prose 페이지를 렌더한다. */
+function renderGallery(count: number) {
+  const figures = Array.from({ length: count }, (_, i) => {
+    const name = String.fromCharCode(97 + i); // a, b, c...
+    return (
+      <figure key={name}>
+        <div className="figure-content">
+          <div className="image-frame">
+            <img
+              className="theme-light"
+              src={`/images/${name}-light.png`}
+              alt={`이미지 ${name.toUpperCase()}`}
+              data-testid={`img-${name}-light`}
+            />
+            <img
+              className="theme-dark"
+              src={`/images/${name}-dark.png`}
+              alt={`이미지 ${name.toUpperCase()}`}
+            />
+          </div>
+        </div>
+      </figure>
+    );
+  });
+
+  return render(
+    <div>
+      <div className="prose">{figures}</div>
+      <ImageLightbox />
+    </div>
+  );
+}
+
+function openAt(letter: string) {
+  act(() => {
+    fireEvent.click(screen.getByTestId(`img-${letter}-light`));
+  });
+}
+
+function getFilmstrip(): HTMLElement | null {
+  return document.querySelector(".lightbox-filmstrip");
+}
+
+function getThumbs(): HTMLButtonElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>(".lightbox-thumb")
+  );
+}
+
+function getCounter(): HTMLElement | null {
+  return document.querySelector(".lightbox-counter");
+}
+
+describe("필름스트립 - 렌더", () => {
+  test("이미지가 2개 이상이면 이미지 수만큼 썸네일을 렌더한다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    expect(getFilmstrip()).toBeInTheDocument();
+    expect(getThumbs()).toHaveLength(3);
+  });
+
+  test("각 썸네일은 해당 이미지의 src를 표시한다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    const thumbImgs = document.querySelectorAll<HTMLImageElement>(
+      ".lightbox-thumb img"
+    );
+    expect(thumbImgs[0].getAttribute("src")).toContain("a-light.png");
+    expect(thumbImgs[1].getAttribute("src")).toContain("b-light.png");
+    expect(thumbImgs[2].getAttribute("src")).toContain("c-light.png");
+  });
+});
+
+describe("필름스트립 - 클릭 이동", () => {
+  test("썸네일 클릭 시 해당 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.click(getThumbs()[2]);
+    });
+
+    expect(getCounter()).toHaveTextContent("3 / 3");
+    expect(
+      document.querySelector(".lightbox-image")?.getAttribute("src")
+    ).toContain("c-light.png");
+  });
+
+  test("썸네일 클릭은 라이트박스를 닫지 않는다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.click(getThumbs()[1]);
+    });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).not.toHaveClass("closing");
+  });
+});
+
+describe("필름스트립 - 활성 표시", () => {
+  test("현재 이미지의 썸네일에 active 클래스와 aria-current가 부여된다", () => {
+    renderGallery(3);
+    openAt("b");
+
+    const thumbs = getThumbs();
+    expect(thumbs[1]).toHaveClass("active");
+    expect(thumbs[1]).toHaveAttribute("aria-current", "true");
+    expect(thumbs[0]).not.toHaveClass("active");
+    expect(thumbs[0]).not.toHaveAttribute("aria-current");
+  });
+
+  test("이동 시 활성 썸네일이 변경된다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "다음 이미지" }));
+    });
+
+    const thumbs = getThumbs();
+    expect(thumbs[1]).toHaveClass("active");
+    expect(thumbs[0]).not.toHaveClass("active");
+  });
+});
+
+describe("필름스트립 - scrollIntoView", () => {
+  test("이미지 이동 시 활성 썸네일을 화면에 스크롤한다", () => {
+    renderGallery(5);
+    openAt("a");
+    (Element.prototype.scrollIntoView as jest.Mock).mockClear();
+
+    act(() => {
+      fireEvent.click(getThumbs()[4]);
+    });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+});
+
+describe("필름스트립 - 접근성", () => {
+  test("필름스트립 컨테이너에 aria-label이 있다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    expect(getFilmstrip()).toHaveAttribute("aria-label");
+  });
+
+  test("각 썸네일 버튼에 위치를 알리는 aria-label이 있다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    const thumbs = getThumbs();
+    expect(thumbs[0]).toHaveAttribute("aria-label", expect.stringContaining("1"));
+    expect(thumbs[2]).toHaveAttribute("aria-label", expect.stringContaining("3"));
+  });
+
+  test("필름스트립 추가 후에도 ESC로 닫힌다 (회귀 방지)", () => {
+    renderGallery(3);
+    openAt("a");
+
+    const dialog = screen.getByRole("dialog");
+    act(() => {
+      fireEvent.keyDown(dialog, { key: "Escape" });
+    });
+
+    expect(dialog).toHaveClass("closing");
+  });
+
+  test("필름스트립 추가 후에도 첫 포커스는 닫기 버튼이다 (회귀 방지)", () => {
+    renderGallery(3);
+    openAt("a");
+
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "이미지 닫기" })
+    );
+  });
+});
+
+describe("필름스트립 - 단일 이미지 하위호환", () => {
+  test("이미지가 1개면 필름스트립을 표시하지 않는다", () => {
+    renderGallery(1);
+    openAt("a");
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getFilmstrip()).not.toBeInTheDocument();
+    expect(getThumbs()).toHaveLength(0);
+  });
+
+  test("이미지가 1개여도 메인 이미지는 표시된다", () => {
+    renderGallery(1);
+    openAt("a");
+
+    const main = document.querySelector(".lightbox-image");
+    expect(main).toBeInTheDocument();
+    expect(main?.getAttribute("src")).toContain("a-light.png");
+  });
+});

--- a/src/components/__tests__/ImageLightboxGallery.test.tsx
+++ b/src/components/__tests__/ImageLightboxGallery.test.tsx
@@ -1,0 +1,282 @@
+import { render, screen, act, fireEvent, within } from "@testing-library/react";
+import ImageLightbox from "../ImageLightbox";
+
+/**
+ * ImageLightbox 갤러리 기능 테스트 (이슈 #116).
+ *
+ * 포스트 내 여러 이미지를 갤러리로 탐색한다.
+ * - 클릭한 이미지가 시작 인덱스
+ * - 좌우 네비게이션 + 위치 인디케이터(N / M)
+ * - clamp 경계 (첫에서 이전 비활성, 마지막에서 다음 비활성)
+ * - 테마쌍은 현재 테마 기준 1개로 카운트
+ * - 단일 이미지일 때 네비 UI 미표시 (하위호환)
+ *
+ * jsdom 기본 테마는 light (document.documentElement에 dark 클래스 없음).
+ */
+
+/** 테마쌍 figure를 포함한 .prose 페이지를 렌더한다. */
+function renderGallery(count: number) {
+  const figures = Array.from({ length: count }, (_, i) => {
+    const name = String.fromCharCode(97 + i); // a, b, c...
+    return (
+      <figure key={name}>
+        <div className="figure-content">
+          <div className="image-frame">
+            <img
+              className="theme-light"
+              src={`/images/${name}-light.png`}
+              alt={`이미지 ${name.toUpperCase()}`}
+              data-testid={`img-${name}-light`}
+            />
+            <img
+              className="theme-dark"
+              src={`/images/${name}-dark.png`}
+              alt={`이미지 ${name.toUpperCase()}`}
+            />
+          </div>
+        </div>
+      </figure>
+    );
+  });
+
+  return render(
+    <div>
+      <div className="prose">{figures}</div>
+      <ImageLightbox />
+    </div>
+  );
+}
+
+/** 특정 figure의 라이트 이미지를 클릭해 갤러리를 연다. */
+function openAt(letter: string) {
+  act(() => {
+    fireEvent.click(screen.getByTestId(`img-${letter}-light`));
+  });
+}
+
+function getCounter(): HTMLElement | null {
+  return document.querySelector(".lightbox-counter");
+}
+
+function getLightboxImageSrc(): string {
+  return (
+    document.querySelector(".lightbox-image")?.getAttribute("src") ?? ""
+  );
+}
+
+afterEach(() => {
+  document.body.style.overflow = "";
+});
+
+describe("갤러리 - 시작 인덱스", () => {
+  test("클릭한 이미지가 시작 위치가 된다", () => {
+    renderGallery(3);
+
+    openAt("b");
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+    expect(getLightboxImageSrc()).toContain("b-light.png");
+  });
+
+  test("첫 이미지 클릭 시 1 / N 로 표시된다", () => {
+    renderGallery(3);
+
+    openAt("a");
+
+    expect(getCounter()).toHaveTextContent("1 / 3");
+  });
+});
+
+describe("갤러리 - 위치 인디케이터", () => {
+  test("테마쌍은 현재 테마 기준 1개로 카운트한다 (중복 없음)", () => {
+    renderGallery(3); // 테마쌍 3개 = 논리 이미지 3개
+
+    openAt("a");
+
+    expect(getCounter()).toHaveTextContent("1 / 3");
+  });
+});
+
+describe("갤러리 - 좌우 네비게이션", () => {
+  test("다음 버튼 클릭 시 다음 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "다음 이미지" }));
+    });
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+    expect(getLightboxImageSrc()).toContain("b-light.png");
+  });
+
+  test("이전 버튼 클릭 시 이전 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("c");
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "이전 이미지" }));
+    });
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+    expect(getLightboxImageSrc()).toContain("b-light.png");
+  });
+
+  test("네비게이션 버튼 클릭은 라이트박스를 닫지 않는다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "다음 이미지" }));
+    });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).not.toHaveClass("closing");
+  });
+});
+
+describe("갤러리 - clamp 경계", () => {
+  test("첫 이미지에서 이전 버튼은 비활성화된다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    expect(screen.getByRole("button", { name: "이전 이미지" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "다음 이미지" })
+    ).not.toBeDisabled();
+  });
+
+  test("마지막 이미지에서 다음 버튼은 비활성화된다", () => {
+    renderGallery(3);
+    openAt("c");
+
+    expect(screen.getByRole("button", { name: "다음 이미지" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "이전 이미지" })
+    ).not.toBeDisabled();
+  });
+
+  test("마지막에서 다음 버튼을 눌러도 인덱스가 넘어가지 않는다", () => {
+    renderGallery(3);
+    openAt("c");
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "다음 이미지" }));
+    });
+
+    expect(getCounter()).toHaveTextContent("3 / 3");
+  });
+});
+
+describe("갤러리 - 키보드 네비게이션", () => {
+  test("→ 화살표로 다음 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "ArrowRight" });
+    });
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+    expect(getLightboxImageSrc()).toContain("b-light.png");
+  });
+
+  test("← 화살표로 이전 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("c");
+
+    act(() => {
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "ArrowLeft" });
+    });
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+    expect(getLightboxImageSrc()).toContain("b-light.png");
+  });
+
+  test("마지막에서 → 화살표를 눌러도 인덱스가 넘어가지 않는다", () => {
+    renderGallery(3);
+    openAt("c");
+
+    act(() => {
+      fireEvent.keyDown(screen.getByRole("dialog"), { key: "ArrowRight" });
+    });
+
+    expect(getCounter()).toHaveTextContent("3 / 3");
+  });
+
+  test("ESC 키는 화살표 핸들러 추가 후에도 닫기를 동작시킨다 (회귀 방지)", () => {
+    renderGallery(3);
+    openAt("a");
+
+    const dialog = screen.getByRole("dialog");
+    act(() => {
+      fireEvent.keyDown(dialog, { key: "Escape" });
+    });
+
+    expect(dialog).toHaveClass("closing");
+  });
+});
+
+describe("갤러리 - 터치 스와이프", () => {
+  function getContent(): HTMLElement {
+    return document.querySelector(".lightbox-content") as HTMLElement;
+  }
+
+  test("왼쪽 스와이프 시 다음 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("a");
+
+    act(() => {
+      fireEvent.touchStart(getContent(), {
+        touches: [{ clientX: 250, clientY: 100 }],
+      });
+      fireEvent.touchEnd(getContent(), {
+        changedTouches: [{ clientX: 100, clientY: 110 }],
+      });
+    });
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+  });
+
+  test("오른쪽 스와이프 시 이전 이미지로 이동한다", () => {
+    renderGallery(3);
+    openAt("c");
+
+    act(() => {
+      fireEvent.touchStart(getContent(), {
+        touches: [{ clientX: 100, clientY: 100 }],
+      });
+      fireEvent.touchEnd(getContent(), {
+        changedTouches: [{ clientX: 250, clientY: 110 }],
+      });
+    });
+
+    expect(getCounter()).toHaveTextContent("2 / 3");
+  });
+});
+
+describe("갤러리 - 단일 이미지 하위호환", () => {
+  test("이미지가 1개면 네비 버튼과 인디케이터를 표시하지 않는다", () => {
+    renderGallery(1);
+    openAt("a");
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "이전 이미지" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "다음 이미지" })
+    ).not.toBeInTheDocument();
+    expect(getCounter()).not.toBeInTheDocument();
+  });
+
+  test("이미지가 1개여도 닫기 버튼은 존재한다", () => {
+    renderGallery(1);
+    openAt("a");
+
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog).getByRole("button", { name: "이미지 닫기" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/useSwipe.test.ts
+++ b/src/hooks/__tests__/useSwipe.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from "@testing-library/react";
+import { useSwipe } from "../useSwipe";
+
+/**
+ * useSwipe 훅 단위 테스트.
+ *
+ * 수평 스와이프 제스처를 감지한다.
+ * - 왼쪽 스와이프(손가락 ←) → onSwipeLeft (다음 이미지)
+ * - 오른쪽 스와이프(손가락 →) → onSwipeRight (이전 이미지)
+ * - 임계값 미만 또는 수직 우세 제스처는 무시 (스크롤 보호)
+ */
+
+type Pt = { clientX: number; clientY: number };
+
+/** TouchEvent 유사 객체 생성 */
+function start(pt: Pt) {
+  return { touches: [pt] } as unknown as React.TouchEvent;
+}
+function end(pt: Pt) {
+  return { changedTouches: [pt] } as unknown as React.TouchEvent;
+}
+
+describe("useSwipe", () => {
+  it("왼쪽으로 충분히 스와이프하면 onSwipeLeft를 호출한다", () => {
+    const onSwipeLeft = jest.fn();
+    const onSwipeRight = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, onSwipeRight })
+    );
+
+    result.current.onTouchStart(start({ clientX: 200, clientY: 100 }));
+    result.current.onTouchEnd(end({ clientX: 100, clientY: 110 }));
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("오른쪽으로 충분히 스와이프하면 onSwipeRight를 호출한다", () => {
+    const onSwipeLeft = jest.fn();
+    const onSwipeRight = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, onSwipeRight })
+    );
+
+    result.current.onTouchStart(start({ clientX: 100, clientY: 100 }));
+    result.current.onTouchEnd(end({ clientX: 200, clientY: 110 }));
+
+    expect(onSwipeRight).toHaveBeenCalledTimes(1);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("이동 거리가 임계값(기본 50px) 미만이면 무시한다", () => {
+    const onSwipeLeft = jest.fn();
+    const onSwipeRight = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, onSwipeRight })
+    );
+
+    result.current.onTouchStart(start({ clientX: 100, clientY: 100 }));
+    result.current.onTouchEnd(end({ clientX: 130, clientY: 100 }));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("수직 이동이 더 크면 무시한다 (세로 스크롤 보호)", () => {
+    const onSwipeLeft = jest.fn();
+    const onSwipeRight = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, onSwipeRight })
+    );
+
+    // deltaX=-60 (임계값 초과)이지만 deltaY=200으로 수직 우세
+    result.current.onTouchStart(start({ clientX: 200, clientY: 50 }));
+    result.current.onTouchEnd(end({ clientX: 140, clientY: 250 }));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("커스텀 임계값을 적용한다", () => {
+    const onSwipeLeft = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, threshold: 100 })
+    );
+
+    // 60px 이동 - 기본값이면 동작하지만 임계값 100이면 무시
+    result.current.onTouchStart(start({ clientX: 200, clientY: 100 }));
+    result.current.onTouchEnd(end({ clientX: 140, clientY: 100 }));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
+
+  it("touchStart 없이 touchEnd만 발생하면 무시한다", () => {
+    const onSwipeLeft = jest.fn();
+    const onSwipeRight = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, onSwipeRight })
+    );
+
+    result.current.onTouchEnd(end({ clientX: 100, clientY: 100 }));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it("touchCancel 후 touchEnd는 무시한다 (인터럽트 보호)", () => {
+    const onSwipeLeft = jest.fn();
+    const onSwipeRight = jest.fn();
+    const { result } = renderHook(() =>
+      useSwipe({ onSwipeLeft, onSwipeRight })
+    );
+
+    result.current.onTouchStart(start({ clientX: 200, clientY: 100 }));
+    result.current.onTouchCancel(); // 시스템 인터럽트로 터치 취소
+    result.current.onTouchEnd(end({ clientX: 100, clientY: 100 }));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onSwipeRight).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSwipe.ts
+++ b/src/hooks/useSwipe.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useRef } from "react";
+
+/**
+ * useSwipe 훅 옵션
+ */
+export interface UseSwipeOptions {
+  /** 왼쪽 스와이프(손가락 ←) 시 호출 — 보통 다음 항목 */
+  onSwipeLeft?: () => void;
+  /** 오른쪽 스와이프(손가락 →) 시 호출 — 보통 이전 항목 */
+  onSwipeRight?: () => void;
+  /** 스와이프로 인정할 최소 수평 이동 거리(px). 기본 50 */
+  threshold?: number;
+}
+
+/**
+ * 요소에 펼쳐 붙일 터치 핸들러
+ */
+export interface SwipeHandlers {
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchEnd: (e: React.TouchEvent) => void;
+  onTouchCancel: () => void;
+}
+
+const DEFAULT_THRESHOLD = 50;
+
+/**
+ * 수평 터치 스와이프 제스처를 감지하는 커스텀 훅.
+ *
+ * - 수평 이동이 임계값 이상이고 수직 이동보다 우세할 때만 스와이프로 인정
+ * - 세로 스크롤과의 충돌을 방지하기 위해 수직 우세 제스처는 무시
+ * - 반환된 핸들러를 대상 요소에 spread 하여 사용
+ */
+export function useSwipe(options: UseSwipeOptions): SwipeHandlers {
+  const { onSwipeLeft, onSwipeRight, threshold = DEFAULT_THRESHOLD } = options;
+
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    startRef.current = { x: touch.clientX, y: touch.clientY };
+  };
+
+  const onTouchEnd = (e: React.TouchEvent) => {
+    const start = startRef.current;
+    startRef.current = null;
+    if (!start) return;
+
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+
+    const deltaX = touch.clientX - start.x;
+    const deltaY = touch.clientY - start.y;
+
+    // 수직 우세 제스처는 스크롤로 간주하여 무시
+    if (Math.abs(deltaX) <= Math.abs(deltaY)) return;
+    if (Math.abs(deltaX) < threshold) return;
+
+    if (deltaX < 0) {
+      onSwipeLeft?.();
+    } else {
+      onSwipeRight?.();
+    }
+  };
+
+  // 시스템 인터럽트(전화 수신, 멀티터치 전환 등)로 터치가 취소되면
+  // 시작 좌표를 비워 다음 터치의 touchend와 섞이지 않도록 한다.
+  const onTouchCancel = () => {
+    startRef.current = null;
+  };
+
+  return { onTouchStart, onTouchEnd, onTouchCancel };
+}

--- a/src/utils/__tests__/galleryImages.test.ts
+++ b/src/utils/__tests__/galleryImages.test.ts
@@ -1,0 +1,241 @@
+import {
+  collectGalleryImages,
+  collectGalleryAt,
+  findGalleryStartIndex,
+  type GalleryImage,
+} from "../galleryImages";
+
+/**
+ * galleryImages 순수 함수 단위 테스트.
+ *
+ * 블로그 포스트의 .prose 컨테이너에서 이미지를 수집하되,
+ * 테마쌍(theme-light / theme-dark)은 현재 활성 테마 기준으로
+ * 하나의 논리적 이미지로 그룹핑한다. (이슈 #116 핵심 난점)
+ */
+
+/** .prose 컨테이너를 생성하고 body에 부착한다. */
+function createProse(html: string): HTMLElement {
+  const div = document.createElement("div");
+  div.className = "prose";
+  div.innerHTML = html;
+  document.body.appendChild(div);
+  return div;
+}
+
+/** 테마쌍 figure 마크업을 생성한다. */
+function themePair(name: string, alt: string): string {
+  return `
+    <figure><div class="figure-content"><div class="image-frame">
+      <img class="theme-light" src="/images/${name}-light.png" alt="${alt}" />
+      <img class="theme-dark" src="/images/${name}-dark.png" alt="${alt}" />
+    </div></div></figure>
+  `;
+}
+
+/** 단일(테마 무관) 이미지 마크업을 생성한다. */
+function singleImage(name: string, alt: string): string {
+  return `<img src="/images/${name}.png" alt="${alt}" />`;
+}
+
+/** 한쪽 테마 이미지만 있는 figure (콘텐츠 작성 오류 상황) */
+function singleSidedPair(
+  name: string,
+  alt: string,
+  side: "light" | "dark"
+): string {
+  return `
+    <figure><div class="figure-content"><div class="image-frame">
+      <img class="theme-${side}" src="/images/${name}-${side}.png" alt="${alt}" />
+    </div></div></figure>
+  `;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("collectGalleryImages", () => {
+  describe("단일 이미지", () => {
+    it("테마 클래스가 없는 단일 이미지를 1개로 수집한다", () => {
+      const prose = createProse(singleImage("screenshot", "스크린샷"));
+
+      const result = collectGalleryImages(prose, "light");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].src).toContain("/images/screenshot.png");
+      expect(result[0].alt).toBe("스크린샷");
+    });
+
+    it("빈 컨테이너는 빈 배열을 반환한다", () => {
+      const prose = createProse("<p>텍스트만 있음</p>");
+
+      expect(collectGalleryImages(prose, "light")).toEqual<GalleryImage[]>([]);
+    });
+  });
+
+  describe("테마쌍 그룹핑", () => {
+    it("테마쌍을 라이트 모드에서 light src 1개로 수집한다", () => {
+      const prose = createProse(themePair("jvm", "JVM 구조"));
+
+      const result = collectGalleryImages(prose, "light");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].src).toContain("/images/jvm-light.png");
+      expect(result[0].alt).toBe("JVM 구조");
+    });
+
+    it("테마쌍을 다크 모드에서 dark src 1개로 수집한다", () => {
+      const prose = createProse(themePair("jvm", "JVM 구조"));
+
+      const result = collectGalleryImages(prose, "dark");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].src).toContain("/images/jvm-dark.png");
+      expect(result[0].alt).toBe("JVM 구조");
+    });
+
+    it("여러 테마쌍을 각각 1개씩만 수집한다 (중복 카운트 없음)", () => {
+      const prose = createProse(
+        themePair("a", "A") + themePair("b", "B") + themePair("c", "C")
+      );
+
+      const result = collectGalleryImages(prose, "light");
+
+      expect(result).toHaveLength(3);
+      expect(result.map((img) => img.alt)).toEqual(["A", "B", "C"]);
+    });
+  });
+
+  describe("한쪽 테마만 있는 figure (fallback)", () => {
+    it("theme-light만 있으면 다크 모드에서도 light src로 대체한다", () => {
+      const prose = createProse(singleSidedPair("solo", "단방향", "light"));
+
+      const result = collectGalleryImages(prose, "dark");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].src).toContain("/images/solo-light.png");
+      expect(result[0].alt).toBe("단방향");
+    });
+
+    it("theme-dark만 있으면 라이트 모드에서도 dark src로 대체한다", () => {
+      const prose = createProse(singleSidedPair("solo", "단방향", "dark"));
+
+      const result = collectGalleryImages(prose, "light");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].src).toContain("/images/solo-dark.png");
+    });
+
+    it("단방향 figure도 findGalleryStartIndex로 올바른 인덱스를 찾는다", () => {
+      const prose = createProse(
+        themePair("a", "A") + singleSidedPair("solo", "단방향", "light")
+      );
+      const soloImg = prose.querySelector(
+        "figure:nth-of-type(2) .theme-light"
+      ) as HTMLImageElement;
+
+      expect(findGalleryStartIndex(prose, "dark", soloImg)).toBe(1);
+    });
+  });
+
+  describe("혼합 + 순서 보존", () => {
+    it("테마쌍과 단일 이미지를 DOM 출현 순서대로 수집한다", () => {
+      const prose = createProse(
+        themePair("first", "첫번째") +
+          singleImage("middle", "중간") +
+          themePair("last", "마지막")
+      );
+
+      const result = collectGalleryImages(prose, "dark");
+
+      expect(result).toHaveLength(3);
+      expect(result.map((img) => img.alt)).toEqual([
+        "첫번째",
+        "중간",
+        "마지막",
+      ]);
+      // 테마쌍은 dark src, 단일은 테마 무관 src
+      expect(result[0].src).toContain("/images/first-dark.png");
+      expect(result[1].src).toContain("/images/middle.png");
+      expect(result[2].src).toContain("/images/last-dark.png");
+    });
+  });
+});
+
+describe("findGalleryStartIndex", () => {
+  it("클릭한 단일 이미지의 인덱스를 반환한다", () => {
+    const prose = createProse(
+      singleImage("a", "A") + singleImage("b", "B") + singleImage("c", "C")
+    );
+    const clicked = prose.querySelectorAll("img")[1] as HTMLImageElement;
+
+    expect(findGalleryStartIndex(prose, "light", clicked)).toBe(1);
+  });
+
+  it("클릭한 theme-light 이미지가 속한 그룹 인덱스를 반환한다", () => {
+    const prose = createProse(themePair("a", "A") + themePair("b", "B"));
+    const clickedLight = prose.querySelector(
+      "figure:nth-of-type(2) .theme-light"
+    ) as HTMLImageElement;
+
+    expect(findGalleryStartIndex(prose, "light", clickedLight)).toBe(1);
+  });
+
+  it("theme-dark 이미지를 클릭해도 같은 테마쌍 그룹 인덱스를 반환한다", () => {
+    const prose = createProse(themePair("a", "A") + themePair("b", "B"));
+    const clickedDark = prose.querySelector(
+      "figure:nth-of-type(2) .theme-dark"
+    ) as HTMLImageElement;
+
+    expect(findGalleryStartIndex(prose, "dark", clickedDark)).toBe(1);
+  });
+
+  it("컨테이너에 없는 이미지는 -1을 반환한다", () => {
+    const prose = createProse(singleImage("a", "A"));
+    const orphan = document.createElement("img");
+
+    expect(findGalleryStartIndex(prose, "light", orphan)).toBe(-1);
+  });
+});
+
+describe("collectGalleryAt", () => {
+  it("이미지 목록과 클릭 시작 인덱스를 함께 반환한다", () => {
+    const prose = createProse(themePair("a", "A") + themePair("b", "B"));
+    const clicked = prose.querySelector(
+      "figure:nth-of-type(2) .theme-light"
+    ) as HTMLImageElement;
+
+    const result = collectGalleryAt(prose, "light", clicked);
+
+    expect(result.images).toHaveLength(2);
+    expect(result.images.map((img) => img.alt)).toEqual(["A", "B"]);
+    expect(result.startIndex).toBe(1);
+  });
+
+  it("collectGalleryImages / findGalleryStartIndex 와 동일한 결과를 낸다", () => {
+    const prose = createProse(
+      themePair("a", "A") + singleImage("b", "B") + themePair("c", "C")
+    );
+    const clicked = prose.querySelectorAll("img")[3] as HTMLImageElement; // c-light
+
+    const combined = collectGalleryAt(prose, "dark", clicked);
+
+    expect(combined.images).toEqual(collectGalleryImages(prose, "dark"));
+    expect(combined.startIndex).toBe(
+      findGalleryStartIndex(prose, "dark", clicked)
+    );
+  });
+
+  it("컨테이너에 없는 이미지는 startIndex -1", () => {
+    const prose = createProse(singleImage("a", "A"));
+
+    const result = collectGalleryAt(
+      prose,
+      "light",
+      document.createElement("img")
+    );
+
+    expect(result.startIndex).toBe(-1);
+    expect(result.images).toHaveLength(1);
+  });
+});

--- a/src/utils/galleryImages.ts
+++ b/src/utils/galleryImages.ts
@@ -1,0 +1,135 @@
+/**
+ * 블로그 포스트 갤러리 이미지 수집 유틸리티.
+ *
+ * .prose 컨테이너 내 이미지를 수집하되, 테마쌍(theme-light / theme-dark)은
+ * 현재 활성 테마 기준으로 하나의 논리적 이미지로 그룹핑한다.
+ * 단일(테마 무관) 이미지는 그대로 1개로 취급한다.
+ */
+
+export type Theme = "light" | "dark";
+
+/** 갤러리에 표시할 논리적 이미지 1개 */
+export interface GalleryImage {
+  /** 현재 테마에 해당하는 이미지 src */
+  src: string;
+  /** 대체 텍스트 */
+  alt: string;
+}
+
+/** 내부 그룹: 화면 표시 정보 + 원본 DOM 노드 매핑 */
+interface ImageGroup extends GalleryImage {
+  /** 이 논리적 이미지를 구성하는 DOM 요소 (단일 1개, 테마쌍 2개) */
+  elements: HTMLImageElement[];
+}
+
+const THEME_LIGHT_CLASS = "theme-light";
+const THEME_DARK_CLASS = "theme-dark";
+
+/** img가 테마쌍의 짝(theme-light/theme-dark)인지 여부 */
+function isThemePaired(img: HTMLImageElement): boolean {
+  return (
+    img.classList.contains(THEME_LIGHT_CLASS) ||
+    img.classList.contains(THEME_DARK_CLASS)
+  );
+}
+
+/** 같은 image-frame 내의 짝 이미지를 찾는다 (없으면 null). */
+function findPair(
+  img: HTMLImageElement,
+  pairClass: string
+): HTMLImageElement | null {
+  return img.parentElement?.querySelector<HTMLImageElement>(
+    `img.${pairClass}`
+  ) ?? null;
+}
+
+/**
+ * 컨테이너 내 이미지를 논리적 그룹 단위로 수집한다 (DOM 출현 순서 보존).
+ */
+function collectGroups(container: HTMLElement, theme: Theme): ImageGroup[] {
+  const images = Array.from(
+    container.querySelectorAll<HTMLImageElement>("img")
+  );
+  const processed = new Set<HTMLImageElement>();
+  const groups: ImageGroup[] = [];
+
+  for (const img of images) {
+    if (processed.has(img)) continue;
+
+    if (isThemePaired(img)) {
+      const light = img.classList.contains(THEME_LIGHT_CLASS)
+        ? img
+        : findPair(img, THEME_LIGHT_CLASS);
+      const dark = img.classList.contains(THEME_DARK_CLASS)
+        ? img
+        : findPair(img, THEME_DARK_CLASS);
+
+      const elements = [light, dark].filter(
+        (el): el is HTMLImageElement => el !== null
+      );
+      const themed = theme === "dark" ? dark ?? light : light ?? dark;
+
+      // themed는 elements가 비어있지 않으면 항상 존재
+      if (themed) {
+        groups.push({ src: themed.src, alt: themed.alt, elements });
+        elements.forEach((el) => processed.add(el));
+        continue;
+      }
+    }
+
+    // 단일(테마 무관) 이미지
+    groups.push({ src: img.src, alt: img.alt, elements: [img] });
+    processed.add(img);
+  }
+
+  return groups;
+}
+
+/**
+ * 컨테이너 내 갤러리 이미지 목록을 현재 테마 기준으로 수집한다.
+ */
+export function collectGalleryImages(
+  container: HTMLElement,
+  theme: Theme
+): GalleryImage[] {
+  return collectGroups(container, theme).map(({ src, alt }) => ({ src, alt }));
+}
+
+/**
+ * 클릭된 이미지가 속한 논리적 갤러리 인덱스를 반환한다.
+ * 컨테이너에 속하지 않으면 -1.
+ */
+export function findGalleryStartIndex(
+  container: HTMLElement,
+  theme: Theme,
+  clicked: HTMLImageElement
+): number {
+  return collectGroups(container, theme).findIndex((group) =>
+    group.elements.includes(clicked)
+  );
+}
+
+/** 갤러리 오픈에 필요한 데이터 */
+export interface GalleryOpenData {
+  images: GalleryImage[];
+  /** 클릭된 이미지의 시작 인덱스 (컨테이너에 없으면 -1) */
+  startIndex: number;
+}
+
+/**
+ * 갤러리 이미지 목록과 클릭 시작 인덱스를 한 번의 DOM 순회로 함께 반환한다.
+ * (collectGalleryImages + findGalleryStartIndex 의 중복 순회 방지)
+ */
+export function collectGalleryAt(
+  container: HTMLElement,
+  theme: Theme,
+  clicked: HTMLImageElement
+): GalleryOpenData {
+  const groups = collectGroups(container, theme);
+  return {
+    images: groups.map(({ src, alt }) => ({ src, alt })),
+    startIndex: groups.findIndex((group) =>
+      group.elements.includes(clicked)
+    ),
+  };
+}


### PR DESCRIPTION
## 개요

블로그 포스트 본문 이미지를 클릭하면 포스트 내 모든 이미지를 좌우 네비게이션으로 탐색할 수 있는 **갤러리 라이트박스**를 제공한다. 기존 단일 이미지 라이트박스(`ImageLightbox`)를 확장했다.

Closes #116

## 주요 변경사항

### 기능
- 이미지 클릭 시 갤러리 오픈, **클릭한 이미지가 시작 위치**
- 좌우 네비게이션 버튼 + 위치 인디케이터(`N / M`)
- 키보드 화살표(← →) 네비게이션, ESC 닫기(기존 유지)
- 모바일 터치 스와이프(왼쪽=다음, 오른쪽=이전)
- 다크/라이트 테마쌍(`-light`/`-dark`)을 **현재 테마 기준 1개로 그룹핑** → 위치 표시 정확
- 단일 이미지 시 네비 UI 미표시(기존 UX 유지, 하위호환)

### 설계 결정
- 테마쌍 수집: `<figure>` 단위 그룹핑 (`useTheme` 활용)
- 네비 경계: clamp(정지) — 첫에서 ← 비활성, 마지막에서 → 비활성
- 키보드 핸들링: `useFocusTrap`은 ESC/Tab 책임 유지(SRP), 화살표는 `ImageLightbox`가 소유
- 갤러리 중 테마 토글 동기화는 MVP 범위에서 제외(열 때 스냅샷)

## 변경 파일

| 파일 | 종류 | 내용 |
|------|------|------|
| `src/utils/galleryImages.ts` | 신규 | 이미지 수집 + 테마쌍 그룹핑 (`collectGalleryImages`, `findGalleryStartIndex`, `collectGalleryAt`) |
| `src/hooks/useSwipe.ts` | 신규 | 네이티브 터치 스와이프 훅 |
| `src/components/ImageLightbox.tsx` | 수정 | 갤러리 상태/네비/키보드/스와이프 |
| `src/app/globals.css` | 수정 | 네비 버튼·인디케이터·다크모드·반응형 |
| `*.test.ts(x)` 3종 | 신규 | 유닛/통합 테스트 |

## 코드 리뷰 반영

- collectGroups 단일 순회 통합(중복 순회 제거)
- 캐시 이미지 onLoad 미발화 시 스피너 멈춤 방지(`key` + ref `complete` 체크)
- `useSwipe` `onTouchCancel` 처리(인터럽트 보호)
- 카운터 `role=status`/`aria-live` 중복 정리
- 테마쌍 단방향 fallback 테스트 보강

## 테스트

- 신규 53개 통과(galleryImages/useSwipe/ImageLightboxGallery), 전체 468개 통과, 회귀 0건
- 커버리지: galleryImages 100%(branch 100%), useSwipe 100%, ImageLightbox 98.65%
- `next build` SSG 19페이지 정상 생성

## 참고

기존 코드 이슈 3건(클릭 img `tabIndex` 잔류, `body.overflow` 복원의 animationend 의존, 닫기 중 재클릭)은 이번 PR 범위 밖(원본 동일)으로 미수정. 후속 처리 검토 가능.