### PR TITLE
feat(career): 경력 타임라인 페이지 추가

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import TechCard from "@/components/TechCard";
 import TiltCard from "@/components/TiltCard";
 import CodeWindow from "@/components/CodeWindow";
@@ -88,6 +89,15 @@ export default function AboutPage() {
                 </ul>
               </div>
             </TiltCard>
+
+            {/* CTA는 TiltCard 밖에 둬 기울임 없이 안정적으로 클릭되도록 함 */}
+            <Link
+              href="/career"
+              className="mt-4 inline-flex items-center gap-1 text-sm font-medium text-amber-700 transition-colors hover:text-amber-900 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              <span role="img" aria-label="가방">💼</span> 경력 자세히 보기
+              <span aria-hidden="true">→</span>
+            </Link>
           </section>
         </ScrollReveal>
 

--- a/src/app/career/page.tsx
+++ b/src/app/career/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import GradientOrbs from "@/components/GradientOrbs";
+import ScrollReveal from "@/components/ScrollReveal";
+import CareerSection from "@/components/CareerSection";
+import { company } from "@/data/career";
+
+export const metadata: Metadata = {
+  title: "Career",
+  description: `${company.name}에서의 풀스택 개발 경력과 주요 작업 타임라인.`,
+};
+
+export default function CareerPage() {
+  return (
+    <div className="relative mx-auto max-w-4xl px-4 py-16">
+      <GradientOrbs />
+
+      <div className="relative">
+        {/* Header */}
+        <ScrollReveal direction="fade" duration={800}>
+          <header className="mb-12">
+            <h1 className="mb-4 text-3xl font-bold md:text-4xl">
+              <span role="img" aria-label="가방">💼</span> Career
+            </h1>
+            <p className="text-zinc-600 dark:text-zinc-400">
+              성능 · 보안 · 아키텍처 · 인프라 관점에서 수행한 주요 작업을 시간순으로 정리했습니다.
+            </p>
+          </header>
+        </ScrollReveal>
+
+        {/* 회사 섹션 (카드 클릭으로 타임라인 접기/펼치기) */}
+        <ScrollReveal direction="up" delay={100}>
+          <CareerSection company={company} />
+        </ScrollReveal>
+      </div>
+    </div>
+  );
+}

--- a/src/app/career/page.tsx
+++ b/src/app/career/page.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import GradientOrbs from "@/components/GradientOrbs";
 import ScrollReveal from "@/components/ScrollReveal";
 import CareerSection from "@/components/CareerSection";
-import { company } from "@/data/career";
+import { careers } from "@/data/career";
 
 export const metadata: Metadata = {
   title: "Career",
-  description: `${company.name}에서의 풀스택 개발 경력과 주요 작업 타임라인.`,
+  description: `${careers[0].name}에서의 풀스택 개발 경력과 주요 작업 타임라인.`,
 };
 
 export default function CareerPage() {
@@ -27,10 +27,12 @@ export default function CareerPage() {
           </header>
         </ScrollReveal>
 
-        {/* 회사 섹션 (카드 클릭으로 타임라인 접기/펼치기) */}
-        <ScrollReveal direction="up" delay={100}>
-          <CareerSection company={company} />
-        </ScrollReveal>
+        {/* 소속별 섹션 (헤더 클릭으로 타임라인 접기/펼치기) */}
+        {careers.map((company, index) => (
+          <ScrollReveal key={company.name} direction="up" delay={100 + index * 50}>
+            <CareerSection company={company} defaultExpanded={index === 0} />
+          </ScrollReveal>
+        ))}
       </div>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,6 +65,7 @@ export default function RootLayout({
               <NavLink href="/">Home</NavLink>
               <NavLink href="/blog">Blog</NavLink>
               <NavLink href="/projects">Projects</NavLink>
+              <NavLink href="/career">Career</NavLink>
               <NavLink href="/about">About</NavLink>
               <SearchButton />
               <ThemeToggle />

--- a/src/components/CareerSection.tsx
+++ b/src/components/CareerSection.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useId, useState } from "react";
+import TiltCard from "@/components/TiltCard";
+import CareerTimeline from "@/components/CareerTimeline";
+import type { Company } from "@/types";
+
+interface CareerSectionProps {
+  company: Company;
+  /** 기본 펼침 여부 (기본값: true) */
+  defaultExpanded?: boolean;
+}
+
+export default function CareerSection({
+  company,
+  defaultExpanded = true,
+}: CareerSectionProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const regionId = useId();
+
+  const toggle = () => setExpanded((prev) => !prev);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggle();
+    }
+  };
+
+  return (
+    <section className="mb-8">
+      {/* 회사 카드 = disclosure 토글 */}
+      <TiltCard className="rounded-2xl">
+        <div
+          role="button"
+          tabIndex={0}
+          aria-expanded={expanded}
+          aria-controls={regionId}
+          onClick={toggle}
+          onKeyDown={handleKeyDown}
+          className="cursor-pointer rounded-2xl border border-white/20 bg-gradient-to-br from-white/30 to-white/20 p-6 shadow-lg backdrop-blur-md transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:from-slate-800/40 dark:to-slate-900/40 dark:focus-visible:ring-blue-500"
+        >
+          <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+            <h2 className="flex items-center gap-2 text-2xl font-semibold">
+              {company.name}
+              {/* chevron: 펼침 시 아래, 접힘 시 우측 */}
+              <svg
+                viewBox="0 0 24 24"
+                className={`h-5 w-5 text-zinc-400 transition-transform duration-300 dark:text-zinc-500 ${
+                  expanded ? "rotate-0" : "-rotate-90"
+                }`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="m6 9 6 6 6-6" />
+              </svg>
+            </h2>
+            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+              {company.period}
+            </span>
+          </div>
+          <p className="mb-3 text-sm font-medium text-amber-700 dark:text-blue-400">
+            {company.role}
+          </p>
+          <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+            {company.description}
+          </p>
+        </div>
+      </TiltCard>
+
+      {/* 펼침 영역: 타임라인 */}
+      {expanded && (
+        <div id={regionId} className="mt-8">
+          <CareerTimeline items={company.items} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/CareerSection.tsx
+++ b/src/components/CareerSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import TiltCard from "@/components/TiltCard";
 import CareerTimeline from "@/components/CareerTimeline";
 import type { Company } from "@/types";
 
@@ -18,66 +17,64 @@ export default function CareerSection({
   const [expanded, setExpanded] = useState(defaultExpanded);
   const regionId = useId();
 
-  const toggle = () => setExpanded((prev) => !prev);
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      toggle();
-    }
-  };
-
   return (
-    <section className="mb-8">
-      {/* 회사 카드 = disclosure 토글 */}
-      <TiltCard className="rounded-2xl">
-        <div
-          role="button"
-          tabIndex={0}
+    <section className="mb-8 overflow-hidden rounded-2xl border border-white/20 bg-gradient-to-br from-white/30 to-white/20 shadow-lg backdrop-blur-md dark:border-white/10 dark:from-slate-800/40 dark:to-slate-900/40">
+      {/* 헤더 = 아코디언 토글 (WAI-ARIA disclosure 패턴) */}
+      <h2 className="text-2xl font-semibold">
+        <button
+          type="button"
           aria-expanded={expanded}
           aria-controls={regionId}
-          onClick={toggle}
-          onKeyDown={handleKeyDown}
-          className="cursor-pointer rounded-2xl border border-white/20 bg-gradient-to-br from-white/30 to-white/20 p-6 shadow-lg backdrop-blur-md transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 dark:border-white/10 dark:from-slate-800/40 dark:to-slate-900/40 dark:focus-visible:ring-blue-500"
+          onClick={() => setExpanded((prev) => !prev)}
+          className="flex w-full items-center justify-between gap-3 p-6 text-left transition-colors hover:bg-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-amber-400 dark:hover:bg-white/5 dark:focus-visible:ring-blue-500"
         >
-          <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
-            <h2 className="flex items-center gap-2 text-2xl font-semibold">
-              {company.name}
-              {/* chevron: 펼침 시 아래, 접힘 시 우측 */}
-              <svg
-                viewBox="0 0 24 24"
-                className={`h-5 w-5 text-zinc-400 transition-transform duration-300 dark:text-zinc-500 ${
-                  expanded ? "rotate-0" : "-rotate-90"
-                }`}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden="true"
-              >
-                <path d="m6 9 6 6 6-6" />
-              </svg>
-            </h2>
-            <span className="text-sm text-zinc-500 dark:text-zinc-400">
+          <span className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <span>{company.name}</span>
+            <span className="text-sm font-medium text-amber-700 dark:text-blue-400">
+              {company.role}
+            </span>
+          </span>
+          <span className="flex shrink-0 items-center gap-2">
+            <span className="text-sm font-normal text-zinc-500 dark:text-zinc-400">
               {company.period}
             </span>
-          </div>
-          <p className="mb-3 text-sm font-medium text-amber-700 dark:text-blue-400">
-            {company.role}
-          </p>
-          <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
-            {company.description}
-          </p>
-        </div>
-      </TiltCard>
+            {/* chevron: 펼침 시 아래, 접힘 시 우측 */}
+            <svg
+              viewBox="0 0 24 24"
+              className={`h-5 w-5 text-zinc-400 transition-transform duration-300 motion-reduce:transition-none dark:text-zinc-500 ${
+                expanded ? "rotate-0" : "-rotate-90"
+              }`}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+          </span>
+        </button>
+      </h2>
 
-      {/* 펼침 영역: 타임라인 */}
-      {expanded && (
-        <div id={regionId} className="mt-8">
-          <CareerTimeline items={company.items} />
+      {/* 접힘 영역: grid-rows 0fr↔1fr 트릭으로 높이 애니메이션 */}
+      <div
+        id={regionId}
+        aria-hidden={!expanded}
+        inert={!expanded ? true : undefined}
+        className={`grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none ${
+          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="px-6 pb-6">
+            <p className="mb-6 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+              {company.description}
+            </p>
+            <CareerTimeline items={company.items} />
+          </div>
         </div>
-      )}
+      </div>
     </section>
   );
 }

--- a/src/components/CareerTimeline.tsx
+++ b/src/components/CareerTimeline.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import TiltCard from "@/components/TiltCard";
+import type { CareerCategory, CareerCategoryFilter, CareerItem } from "@/types";
+import {
+  sortByDateDesc,
+  filterByCategory,
+  extractCategoriesWithCount,
+} from "@/utils/career";
+
+interface CareerTimelineProps {
+  items: CareerItem[];
+}
+
+/** 유형별 배지 색상 (light / dark 대응) */
+const categoryColor: Record<CareerCategory, string> = {
+  성능: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300",
+  보안: "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300",
+  아키텍처:
+    "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300",
+  인프라:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+};
+
+/** 타임라인 노드 점 색상 */
+const nodeColor: Record<CareerCategory, string> = {
+  성능: "bg-sky-400 dark:bg-sky-500",
+  보안: "bg-rose-400 dark:bg-rose-500",
+  아키텍처: "bg-violet-400 dark:bg-violet-500",
+  인프라: "bg-emerald-400 dark:bg-emerald-500",
+};
+
+export default function CareerTimeline({ items }: CareerTimelineProps) {
+  const [filter, setFilter] = useState<CareerCategoryFilter>("전체");
+
+  const categoryCounts = useMemo(
+    () => extractCategoriesWithCount(items),
+    [items]
+  );
+
+  const visibleItems = useMemo(
+    () => sortByDateDesc(filterByCategory(items, filter)),
+    [items, filter]
+  );
+
+  const chips: { label: CareerCategoryFilter; count: number }[] = [
+    { label: "전체", count: items.length },
+    ...categoryCounts.map((c) => ({ label: c.category, count: c.count })),
+  ];
+
+  return (
+    <div>
+      {/* 유형 필터 칩 */}
+      <div
+        className="mb-8 flex flex-wrap gap-2"
+        role="group"
+        aria-label="작업 유형 필터"
+      >
+        {chips.map(({ label, count }) => {
+          const isActive = filter === label;
+          return (
+            <button
+              key={label}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setFilter(label)}
+              className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                isActive
+                  ? "bg-amber-500 text-white dark:bg-blue-600"
+                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+              }`}
+            >
+              <span>{label}</span>
+              <span className={isActive ? "text-white/80" : "text-zinc-400 dark:text-zinc-500"}>
+                {count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 세로 타임라인 */}
+      <ol className="relative ml-2 border-l border-zinc-200 dark:border-zinc-700">
+        {visibleItems.map((item) => (
+          <li key={item.id} className="relative ml-6 pb-8 last:pb-0">
+            {/* 노드 점 */}
+            <span
+              className={`absolute -left-[1.6rem] top-1.5 h-3 w-3 rounded-full ring-4 ring-white dark:ring-zinc-900 ${nodeColor[item.category]}`}
+              aria-hidden="true"
+            />
+
+            {/* 카드 */}
+            <TiltCard className="rounded-xl" maxTilt={6} scale={1.01}>
+              <div className="rounded-xl border border-white/20 bg-gradient-to-br from-white/30 to-white/20 p-4 shadow-sm backdrop-blur-md transition-all duration-300 hover:shadow-md dark:border-white/10 dark:from-slate-800/40 dark:to-slate-900/40">
+              <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${categoryColor[item.category]}`}
+                >
+                  {item.category}
+                </span>
+                <time className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {item.period ?? item.date}
+                </time>
+                {item.highlight && (
+                  <span
+                    className="text-xs text-amber-500 dark:text-amber-400"
+                    role="img"
+                    aria-label="대표 성과"
+                  >
+                    ⭐
+                  </span>
+                )}
+              </div>
+
+              <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                {item.title}
+              </h3>
+              <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+                {item.summary}
+              </p>
+              </div>
+            </TiltCard>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/components/CareerTimeline.tsx
+++ b/src/components/CareerTimeline.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import TiltCard from "@/components/TiltCard";
 import type { CareerCategory, CareerCategoryFilter, CareerItem } from "@/types";
 import {
-  sortByDateDesc,
   filterByCategory,
   extractCategoriesWithCount,
+  groupByYear,
 } from "@/utils/career";
 
 interface CareerTimelineProps {
@@ -39,8 +39,8 @@ export default function CareerTimeline({ items }: CareerTimelineProps) {
     [items]
   );
 
-  const visibleItems = useMemo(
-    () => sortByDateDesc(filterByCategory(items, filter)),
+  const yearGroups = useMemo(
+    () => groupByYear(filterByCategory(items, filter)),
     [items, filter]
   );
 
@@ -48,6 +48,8 @@ export default function CareerTimeline({ items }: CareerTimelineProps) {
     { label: "전체", count: items.length },
     ...categoryCounts.map((c) => ({ label: c.category, count: c.count })),
   ];
+
+  const hasHighlight = items.some((item) => item.highlight);
 
   return (
     <div>
@@ -80,48 +82,72 @@ export default function CareerTimeline({ items }: CareerTimelineProps) {
         })}
       </div>
 
-      {/* 세로 타임라인 */}
+      {/* ⭐ 범례 */}
+      {hasHighlight && (
+        <p className="mb-6 flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400">
+          <span aria-hidden="true">⭐</span>
+          <span>대표 성과</span>
+        </p>
+      )}
+
+      {/* 연도별 세로 타임라인 */}
       <ol className="relative ml-2 border-l border-zinc-200 dark:border-zinc-700">
-        {visibleItems.map((item) => (
-          <li key={item.id} className="relative ml-6 pb-8 last:pb-0">
-            {/* 노드 점 */}
-            <span
-              className={`absolute -left-[1.6rem] top-1.5 h-3 w-3 rounded-full ring-4 ring-white dark:ring-zinc-900 ${nodeColor[item.category]}`}
-              aria-hidden="true"
-            />
+        {yearGroups.map((group) => (
+          <Fragment key={group.year}>
+            {/* 연도 마커 */}
+            <li className="relative ml-6 mb-5">
+              <span
+                className="absolute -left-[2.05rem] top-0.5 h-4 w-4 rounded-full bg-zinc-300 ring-4 ring-white dark:bg-zinc-600 dark:ring-zinc-900"
+                aria-hidden="true"
+              />
+              <span className="text-sm font-bold tracking-wide text-zinc-700 dark:text-zinc-300">
+                {group.year}
+              </span>
+            </li>
 
-            {/* 카드 */}
-            <TiltCard className="rounded-xl" maxTilt={6} scale={1.01}>
-              <div className="rounded-xl border border-white/20 bg-gradient-to-br from-white/30 to-white/20 p-4 shadow-sm backdrop-blur-md transition-all duration-300 hover:shadow-md dark:border-white/10 dark:from-slate-800/40 dark:to-slate-900/40">
-              <div className="mb-1.5 flex flex-wrap items-center gap-2">
+            {/* 해당 연도 항목 */}
+            {group.items.map((item) => (
+              <li key={item.id} className="relative ml-6 pb-8">
+                {/* 노드 점 */}
                 <span
-                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${categoryColor[item.category]}`}
-                >
-                  {item.category}
-                </span>
-                <time className="text-xs text-zinc-500 dark:text-zinc-400">
-                  {item.period ?? item.date}
-                </time>
-                {item.highlight && (
-                  <span
-                    className="text-xs text-amber-500 dark:text-amber-400"
-                    role="img"
-                    aria-label="대표 성과"
-                  >
-                    ⭐
-                  </span>
-                )}
-              </div>
+                  className={`absolute -left-[1.6rem] top-1.5 h-3 w-3 rounded-full ring-4 ring-white dark:ring-zinc-900 ${nodeColor[item.category]}`}
+                  aria-hidden="true"
+                />
 
-              <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
-                {item.title}
-              </h3>
-              <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
-                {item.summary}
-              </p>
-              </div>
-            </TiltCard>
-          </li>
+                {/* 카드 */}
+                <TiltCard className="rounded-xl" maxTilt={6} scale={1.01}>
+                  <div className="rounded-xl border border-white/20 bg-gradient-to-br from-white/30 to-white/20 p-4 shadow-sm backdrop-blur-md transition-all duration-300 hover:shadow-md dark:border-white/10 dark:from-slate-800/40 dark:to-slate-900/40">
+                    <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${categoryColor[item.category]}`}
+                      >
+                        {item.category}
+                      </span>
+                      <time className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {item.period ?? item.date}
+                      </time>
+                      {item.highlight && (
+                        <span
+                          className="text-xs text-amber-500 dark:text-amber-400"
+                          role="img"
+                          aria-label="대표 성과"
+                        >
+                          ⭐
+                        </span>
+                      )}
+                    </div>
+
+                    <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                      {item.title}
+                    </h3>
+                    <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+                      {item.summary}
+                    </p>
+                  </div>
+                </TiltCard>
+              </li>
+            ))}
+          </Fragment>
         ))}
       </ol>
     </div>

--- a/src/components/CareerTimeline.tsx
+++ b/src/components/CareerTimeline.tsx
@@ -21,6 +21,8 @@ const categoryColor: Record<CareerCategory, string> = {
     "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300",
   인프라:
     "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  프로젝트:
+    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
 };
 
 /** 타임라인 노드 점 색상 */
@@ -29,6 +31,7 @@ const nodeColor: Record<CareerCategory, string> = {
   보안: "bg-rose-400 dark:bg-rose-500",
   아키텍처: "bg-violet-400 dark:bg-violet-500",
   인프라: "bg-emerald-400 dark:bg-emerald-500",
+  프로젝트: "bg-amber-400 dark:bg-amber-500",
 };
 
 export default function CareerTimeline({ items }: CareerTimelineProps) {
@@ -50,10 +53,13 @@ export default function CareerTimeline({ items }: CareerTimelineProps) {
   ];
 
   const hasHighlight = items.some((item) => item.highlight);
+  // 유형이 1개뿐이면 필터링 의미가 없으므로 칩을 숨긴다
+  const showFilter = categoryCounts.length >= 2;
 
   return (
     <div>
       {/* 유형 필터 칩 */}
+      {showFilter && (
       <div
         className="mb-8 flex flex-wrap gap-2"
         role="group"
@@ -81,6 +87,7 @@ export default function CareerTimeline({ items }: CareerTimelineProps) {
           );
         })}
       </div>
+      )}
 
       {/* ⭐ 범례 */}
       {hasHighlight && (
@@ -143,6 +150,26 @@ export default function CareerTimeline({ items }: CareerTimelineProps) {
                     <p className="mt-1 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
                       {item.summary}
                     </p>
+
+                    {item.repoUrl && (
+                      <a
+                        href={item.repoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="relative z-10 mt-3 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-50 hover:text-amber-900 dark:text-blue-400 dark:hover:bg-white/5 dark:hover:text-blue-300"
+                      >
+                        <svg
+                          viewBox="0 0 24 24"
+                          className="h-4 w-4"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                        </svg>
+                        GitHub
+                        <span aria-hidden="true">↗</span>
+                      </a>
+                    )}
                   </div>
                 </TiltCard>
               </li>

--- a/src/components/__tests__/CareerSection.test.tsx
+++ b/src/components/__tests__/CareerSection.test.tsx
@@ -25,62 +25,76 @@ const company: Company = {
   ],
 };
 
+/** 토글 버튼과 그것이 제어하는 접힘 영역을 함께 반환한다. */
+function getToggleAndRegion() {
+  const toggle = screen.getByRole("button", { name: /테스트회사/ });
+  const regionId = toggle.getAttribute("aria-controls")!;
+  const region = document.getElementById(regionId)!;
+  return { toggle, region };
+}
+
 describe("CareerSection", () => {
-  it("기본 상태(펼침)에서 타임라인 항목이 보인다", () => {
+  it("헤더 토글은 네이티브 button 요소다 (키보드 기본 지원)", () => {
     render(<CareerSection company={company} />);
 
-    expect(screen.getByText("성능 개선 작업")).toBeInTheDocument();
-    expect(screen.getByText("보안 강화 작업")).toBeInTheDocument();
+    const { toggle } = getToggleAndRegion();
+    expect(toggle.tagName).toBe("BUTTON");
   });
 
-  it("토글이 기본적으로 aria-expanded=true 이다", () => {
+  it("기본 상태는 펼침 (aria-expanded=true, 영역 노출)", () => {
     render(<CareerSection company={company} />);
 
-    expect(screen.getByRole("button", { name: /테스트회사/ })).toHaveAttribute(
-      "aria-expanded",
-      "true"
-    );
-  });
-
-  it("카드 클릭 시 타임라인이 접힌다", () => {
-    render(<CareerSection company={company} />);
-
-    fireEvent.click(screen.getByRole("button", { name: /테스트회사/ }));
-
-    expect(screen.queryByText("성능 개선 작업")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /테스트회사/ })).toHaveAttribute(
-      "aria-expanded",
-      "false"
-    );
-  });
-
-  it("재클릭 시 타임라인이 다시 펼쳐진다", () => {
-    render(<CareerSection company={company} />);
-    const toggle = screen.getByRole("button", { name: /테스트회사/ });
-
-    fireEvent.click(toggle);
-    fireEvent.click(toggle);
-
-    expect(screen.getByText("성능 개선 작업")).toBeInTheDocument();
+    const { toggle, region } = getToggleAndRegion();
     expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(region).toHaveAttribute("aria-hidden", "false");
+    expect(screen.getByText("성능 개선 작업")).toBeInTheDocument();
   });
 
-  it("Enter 키로도 토글된다", () => {
+  it("헤더 클릭 시 접힌다 (aria-expanded=false, 영역 숨김)", () => {
     render(<CareerSection company={company} />);
-    const toggle = screen.getByRole("button", { name: /테스트회사/ });
 
-    fireEvent.keyDown(toggle, { key: "Enter" });
+    const { toggle, region } = getToggleAndRegion();
+    fireEvent.click(toggle);
 
-    expect(screen.queryByText("성능 개선 작업")).not.toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(region).toHaveAttribute("aria-hidden", "true");
   });
 
-  it("회사 정보(역할·기간·설명)는 접힘 여부와 무관하게 보인다", () => {
+  it("재클릭 시 다시 펼쳐진다", () => {
     render(<CareerSection company={company} />);
-    const toggle = screen.getByRole("button", { name: /테스트회사/ });
 
+    const { toggle, region } = getToggleAndRegion();
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(region).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("접힘 영역은 toggle의 aria-controls 와 연결된다", () => {
+    render(<CareerSection company={company} />);
+
+    const { toggle, region } = getToggleAndRegion();
+    expect(region).not.toBeNull();
+    expect(toggle.getAttribute("aria-controls")).toBe(region.id);
+  });
+
+  it("회사명·역할·기간 헤더는 접힘 여부와 무관하게 보인다", () => {
+    render(<CareerSection company={company} />);
+
+    const { toggle } = getToggleAndRegion();
     fireEvent.click(toggle); // 접기
 
+    expect(screen.getByText("테스트회사")).toBeInTheDocument();
     expect(screen.getByText("풀스택 개발")).toBeInTheDocument();
-    expect(screen.getByText("테스트 회사 설명")).toBeInTheDocument();
+    expect(screen.getByText("2022.06 ~ 재직 중")).toBeInTheDocument();
+  });
+
+  it("defaultExpanded=false 이면 처음부터 접혀 있다", () => {
+    render(<CareerSection company={company} defaultExpanded={false} />);
+
+    const { toggle, region } = getToggleAndRegion();
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(region).toHaveAttribute("aria-hidden", "true");
   });
 });

--- a/src/components/__tests__/CareerSection.test.tsx
+++ b/src/components/__tests__/CareerSection.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import CareerSection from "../CareerSection";
+import type { Company } from "@/types";
+
+const company: Company = {
+  name: "테스트회사",
+  role: "풀스택 개발",
+  period: "2022.06 ~ 재직 중",
+  description: "테스트 회사 설명",
+  items: [
+    {
+      id: "a",
+      title: "성능 개선 작업",
+      summary: "성능 요약",
+      category: "성능",
+      date: "2025.09",
+    },
+    {
+      id: "b",
+      title: "보안 강화 작업",
+      summary: "보안 요약",
+      category: "보안",
+      date: "2024.03",
+    },
+  ],
+};
+
+describe("CareerSection", () => {
+  it("기본 상태(펼침)에서 타임라인 항목이 보인다", () => {
+    render(<CareerSection company={company} />);
+
+    expect(screen.getByText("성능 개선 작업")).toBeInTheDocument();
+    expect(screen.getByText("보안 강화 작업")).toBeInTheDocument();
+  });
+
+  it("토글이 기본적으로 aria-expanded=true 이다", () => {
+    render(<CareerSection company={company} />);
+
+    expect(screen.getByRole("button", { name: /테스트회사/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("카드 클릭 시 타임라인이 접힌다", () => {
+    render(<CareerSection company={company} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /테스트회사/ }));
+
+    expect(screen.queryByText("성능 개선 작업")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /테스트회사/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("재클릭 시 타임라인이 다시 펼쳐진다", () => {
+    render(<CareerSection company={company} />);
+    const toggle = screen.getByRole("button", { name: /테스트회사/ });
+
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(screen.getByText("성능 개선 작업")).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("Enter 키로도 토글된다", () => {
+    render(<CareerSection company={company} />);
+    const toggle = screen.getByRole("button", { name: /테스트회사/ });
+
+    fireEvent.keyDown(toggle, { key: "Enter" });
+
+    expect(screen.queryByText("성능 개선 작업")).not.toBeInTheDocument();
+  });
+
+  it("회사 정보(역할·기간·설명)는 접힘 여부와 무관하게 보인다", () => {
+    render(<CareerSection company={company} />);
+    const toggle = screen.getByRole("button", { name: /테스트회사/ });
+
+    fireEvent.click(toggle); // 접기
+
+    expect(screen.getByText("풀스택 개발")).toBeInTheDocument();
+    expect(screen.getByText("테스트 회사 설명")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/CareerTimeline.test.tsx
+++ b/src/components/__tests__/CareerTimeline.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, within } from "@testing-library/react";
+import CareerTimeline from "../CareerTimeline";
+import type { CareerItem } from "@/types";
+
+const multiCategoryItems: CareerItem[] = [
+  { id: "a", title: "성능 작업", summary: "요약", category: "성능", date: "2025.09" },
+  { id: "b", title: "보안 작업", summary: "요약", category: "보안", date: "2024.03" },
+];
+
+const singleCategoryItems: CareerItem[] = [
+  {
+    id: "p1",
+    title: "프로젝트 1",
+    summary: "요약",
+    category: "프로젝트",
+    date: "2021.05",
+    repoUrl: "https://github.com/kmg733/BoT",
+  },
+  {
+    id: "p2",
+    title: "프로젝트 2",
+    summary: "요약",
+    category: "프로젝트",
+    date: "2020.05",
+  },
+];
+
+describe("CareerTimeline 필터 칩 노출", () => {
+  it("유형이 2개 이상이면 필터 그룹을 렌더한다", () => {
+    render(<CareerTimeline items={multiCategoryItems} />);
+
+    expect(
+      screen.getByRole("group", { name: "작업 유형 필터" })
+    ).toBeInTheDocument();
+  });
+
+  it("유형이 1개뿐이면 필터 그룹을 렌더하지 않는다", () => {
+    render(<CareerTimeline items={singleCategoryItems} />);
+
+    expect(
+      screen.queryByRole("group", { name: "작업 유형 필터" })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("CareerTimeline GitHub 링크", () => {
+  it("repoUrl이 있으면 해당 저장소로의 링크를 렌더한다", () => {
+    render(<CareerTimeline items={singleCategoryItems} />);
+
+    const card = screen.getByText("프로젝트 1").closest("li")!;
+    const link = within(card).getByRole("link");
+
+    expect(link).toHaveAttribute("href", "https://github.com/kmg733/BoT");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("repoUrl이 없으면 링크를 렌더하지 않는다", () => {
+    render(<CareerTimeline items={singleCategoryItems} />);
+
+    const card = screen.getByText("프로젝트 2").closest("li")!;
+
+    expect(within(card).queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/src/data/career.ts
+++ b/src/data/career.ts
@@ -1,0 +1,156 @@
+import type { Company } from "@/types";
+
+/**
+ * 경력 데이터
+ *
+ * 항목을 추가하려면 `items` 배열에 새 CareerItem을 추가하세요.
+ * - date 형식: "YYYY.MM" (정렬·표기 기준)
+ * - highlight: 대표 성과 강조(⭐)
+ * - postSlug: 향후 블로그 글 연결용
+ */
+export const company: Company = {
+  name: "지란지교데이터",
+  role: "백엔드 ~ 프론트엔드 풀스택 개발",
+  period: "2022.06 ~ 재직 중",
+  description:
+    "개인정보 검출·비식별 조치 솔루션의 백엔드(API·쿼리·보안)부터 프론트엔드(UI·성능)까지 풀스택으로 개발했습니다. 대용량 데이터 처리 성능 개선, 인증·인가 보안 기반 구축, 트랜잭션·동시성 정합성 설계, 품질·인프라 개선을 담당했습니다.",
+  items: [
+    // ── 성능 ──────────────────────────────────────────────
+    {
+      id: "perf-cursor-stream",
+      title: "MyBatis Cursor 스트리밍으로 대용량 처리 OOM 해결",
+      summary:
+        "전건 메모리 적재를 Cursor 스트리밍 + 제네릭 헬퍼로 전환, 처리 메모리 2.5GB → 500MB (80% 절감)",
+      category: "성능",
+      date: "2025.09",
+      period: "2025.06 ~ 2025.09",
+      highlight: true,
+    },
+    {
+      id: "perf-render-21x",
+      title: "설정 화면 렌더링 21배 개선",
+      summary:
+        "polling + 무조건 리로드 안티패턴을 재귀 + diff 갱신으로 전환, LCP 7.93s → 0.38s (21배)",
+      category: "성능",
+      date: "2025.03",
+      highlight: true,
+    },
+    {
+      id: "perf-excel-stream",
+      title: "대용량 Excel 업로드/다운로드 스트리밍 전환",
+      summary:
+        "SAX 스트리밍 읽기 + SXSSF 쓰기로 메모리 안정화, ZIP Bomb·리소스 누수 방어 적용",
+      category: "성능",
+      date: "2025.10",
+      period: "2025.10 ~ 2025.12",
+      highlight: true,
+    },
+    {
+      id: "perf-n1-async",
+      title: "N+1 동기 호출을 단일 비동기 API로 전환",
+      summary:
+        "재귀적 N+1 동기 호출을 백·프론트 양쪽에서 단일 비동기 호출로 통합, UI 블로킹 해소",
+      category: "성능",
+      date: "2026.03",
+      highlight: true,
+    },
+    {
+      id: "perf-detail-33",
+      title: "상세 조회 속도 33% 단축",
+      summary: "무거운 SQL 연산을 Java 레이어로 이전, 15,452ms → 10,286ms (33% 단축)",
+      category: "성능",
+      date: "2025.07",
+    },
+    {
+      id: "perf-engine-assign",
+      title: "진단 엔진 배정 알고리즘 개선",
+      summary:
+        '"가용 최대" 방식을 "부하 최소" 휴리스틱으로 변경해 엔진 간 작업 쏠림 완화',
+      category: "성능",
+      date: "2024.11",
+    },
+
+    // ── 보안 ──────────────────────────────────────────────
+    {
+      id: "sec-spring-security",
+      title: "Spring Security 6 인증·인가 아키텍처 from scratch 구축",
+      summary:
+        "필터 체인·커스텀 AuthenticationProvider·핸들러를 직접 구성해 통합 시스템의 인증·인가 골격 구축",
+      category: "보안",
+      date: "2024.03",
+      highlight: true,
+    },
+    {
+      id: "sec-web-vuln",
+      title: "OWASP 웹 취약점 조치 (SQLi·CSP·권한우회)",
+      summary:
+        "MyBatis `${}` → `#{}` 치환, CSP 인라인 분리, 동적 권한 체크 등 웹 취약점 다발 조치",
+      category: "보안",
+      date: "2025.08",
+      period: "2025.08 ~ 2026.06",
+      highlight: true,
+    },
+    {
+      id: "sec-otp-2fa",
+      title: "OTP 2FA · IP 접속 제한 인증 강화",
+      summary: "Spring Security 확장점을 활용한 TOTP 기반 2단계 인증과 IP 화이트리스트 제한 적용",
+      category: "보안",
+      date: "2024.04",
+      period: "2024.03 ~ 2024.04",
+    },
+    {
+      id: "sec-bruteforce",
+      title: "로그인 무차별 대입(Brute-force) 방어",
+      summary: "실패 횟수 기반 차단으로 무차별 대입 공격 방어",
+      category: "보안",
+      date: "2024.03",
+    },
+
+    // ── 아키텍처 ──────────────────────────────────────────
+    {
+      id: "arch-tx-isolation",
+      title: "트랜잭션 격리로 Silent Rollback 방지",
+      summary:
+        "부가 작업 실패가 주 트랜잭션을 조용히 롤백시키던 문제를 REQUIRES_NEW로 격리, 책임 분리",
+      category: "아키텍처",
+      date: "2026.04",
+      highlight: true,
+    },
+    {
+      id: "arch-race-condition",
+      title: "승인자 조회 Race Condition 구조적 해소",
+      summary: "두 번 조회로 발생하던 race drift를 단일 쿼리 통합으로 구조에서 제거",
+      category: "아키텍처",
+      date: "2026.04",
+      highlight: true,
+    },
+
+    // ── 인프라 ────────────────────────────────────────────
+    {
+      id: "infra-i18n",
+      title: "한/영 i18n 다국어 인프라 구축",
+      summary:
+        "SSR/CSR 동시 지원, localStorage 캐싱, cold start 시 키 노출 문제 해결까지 i18n 기반 구축",
+      category: "인프라",
+      date: "2026.03",
+      period: "2026.01 ~ 2026.03",
+      highlight: true,
+    },
+    {
+      id: "infra-testcontainers",
+      title: "Testcontainers 기반 통합 테스트 인프라",
+      summary:
+        "실제 PostgreSQL 컨테이너로 동적 SQL·JSONB·타입 변환 등 Mock으로 불가능한 SQL 검증",
+      category: "인프라",
+      date: "2026.05",
+      highlight: true,
+    },
+    {
+      id: "infra-springboot-upgrade",
+      title: "Spring Boot 단계 업그레이드 (3.2 → 3.5)",
+      summary: "단계적 업그레이드 + matcher 마이그레이션으로 Tomcat 취약점 해소",
+      category: "인프라",
+      date: "2025.11",
+    },
+  ],
+};

--- a/src/data/career.ts
+++ b/src/data/career.ts
@@ -45,7 +45,6 @@ const jirandata: Company = {
       category: "성능",
       date: "2025.10",
       period: "2025.10 ~ 2025.12",
-      highlight: true,
     },
     {
       id: "perf-n1-async",
@@ -54,7 +53,6 @@ const jirandata: Company = {
         "재귀적 N+1 동기 호출을 백·프론트 양쪽에서 단일 비동기 호출로 통합, UI 블로킹 해소",
       category: "성능",
       date: "2026.03",
-      highlight: true,
     },
     {
       id: "perf-detail-33",
@@ -80,7 +78,6 @@ const jirandata: Company = {
         "필터 체인·커스텀 AuthenticationProvider·핸들러를 직접 구성해 통합 시스템의 인증·인가 골격 구축",
       category: "보안",
       date: "2024.03",
-      highlight: true,
     },
     {
       id: "sec-web-vuln",
@@ -90,7 +87,6 @@ const jirandata: Company = {
       category: "보안",
       date: "2025.08",
       period: "2025.08 ~ 2026.06",
-      highlight: true,
     },
     {
       id: "sec-otp-2fa",
@@ -116,7 +112,6 @@ const jirandata: Company = {
         "부가 작업 실패가 주 트랜잭션을 조용히 롤백시키던 문제를 REQUIRES_NEW로 격리, 책임 분리",
       category: "아키텍처",
       date: "2026.04",
-      highlight: true,
     },
     {
       id: "arch-race-condition",
@@ -124,7 +119,6 @@ const jirandata: Company = {
       summary: "두 번 조회로 발생하던 race drift를 단일 쿼리 통합으로 구조에서 제거",
       category: "아키텍처",
       date: "2026.04",
-      highlight: true,
     },
 
     // ── 인프라 ────────────────────────────────────────────

--- a/src/data/career.ts
+++ b/src/data/career.ts
@@ -1,14 +1,16 @@
 import type { Company } from "@/types";
 
 /**
- * 경력 데이터
+ * 경력 데이터 (최신 소속이 먼저 오도록 정렬)
  *
- * 항목을 추가하려면 `items` 배열에 새 CareerItem을 추가하세요.
+ * 소속을 추가하려면 `careers` 배열에 새 Company를 추가하세요.
+ * 항목을 추가하려면 각 소속의 `items` 배열에 CareerItem을 추가하세요.
  * - date 형식: "YYYY.MM" (정렬·표기 기준)
  * - highlight: 대표 성과 강조(⭐)
+ * - repoUrl: GitHub 등 외부 링크
  * - postSlug: 향후 블로그 글 연결용
  */
-export const company: Company = {
+const jirandata: Company = {
   name: "지란지교데이터",
   role: "백엔드 ~ 프론트엔드 풀스택 개발",
   period: "2022.06 ~ 재직 중",
@@ -154,3 +156,43 @@ export const company: Company = {
     },
   ],
 };
+
+const nsl: Company = {
+  name: "공주대학교 네트워크보안연구실 (Network Security Lab)",
+  role: "학부 연구생",
+  period: "2019.06 ~ 2022.02",
+  description:
+    "학부 연구생으로 IoT·블록체인·임베디드 기반의 보안 프로젝트를 수행했습니다.",
+  items: [
+    {
+      id: "nsl-bot",
+      title: "블록체인을 이용한 IoT 보안 기능 고도화",
+      summary: "블록체인을 활용해 IoT 환경의 보안 기능을 고도화한 프로젝트",
+      category: "프로젝트",
+      date: "2021.05",
+      period: "2021.05 ~ 2021.10",
+      repoUrl: "https://github.com/kmg733/BoT",
+    },
+    {
+      id: "nsl-imcp",
+      title: "지능형 미아방지 시스템",
+      summary: "IoT 기반으로 미아 발생을 예방·탐지하는 지능형 시스템",
+      category: "프로젝트",
+      date: "2020.05",
+      period: "2020.05 ~ 2020.10",
+      repoUrl: "https://github.com/kmg733/IMCP",
+    },
+    {
+      id: "nsl-lab-iot",
+      title: "IoT를 이용한 연구실 자동화 시스템",
+      summary: "IoT 디바이스로 연구실 환경을 모니터링·제어하는 자동화 시스템",
+      category: "프로젝트",
+      date: "2019.11",
+      period: "2019.11 ~ 2020.03",
+      repoUrl: "https://github.com/kmg733/lab_iot",
+    },
+  ],
+};
+
+/** 최신 소속이 먼저 (페이지 렌더 순서) */
+export const careers: Company[] = [jirandata, nsl];

--- a/src/types/career.ts
+++ b/src/types/career.ts
@@ -3,7 +3,12 @@
  */
 
 /** 작업 유형 분류 (엔지니어링 시그널 기준) */
-export type CareerCategory = "성능" | "보안" | "아키텍처" | "인프라";
+export type CareerCategory =
+  | "성능"
+  | "보안"
+  | "아키텍처"
+  | "인프라"
+  | "프로젝트";
 
 /** 유형 필터 옵션 (전체 + 각 유형) */
 export type CareerCategoryFilter = "전체" | CareerCategory;
@@ -25,6 +30,8 @@ export interface CareerItem {
   highlight?: boolean;
   /** 향후 블로그 글 연결용 slug */
   postSlug?: string;
+  /** GitHub 저장소 등 외부 링크 */
+  repoUrl?: string;
 }
 
 /** 회사 경력 (회사 정보 + 작업 항목 목록) */

--- a/src/types/career.ts
+++ b/src/types/career.ts
@@ -1,0 +1,42 @@
+/**
+ * 경력(Career) 타임라인 도메인 타입
+ */
+
+/** 작업 유형 분류 (엔지니어링 시그널 기준) */
+export type CareerCategory = "성능" | "보안" | "아키텍처" | "인프라";
+
+/** 유형 필터 옵션 (전체 + 각 유형) */
+export type CareerCategoryFilter = "전체" | CareerCategory;
+
+/** 타임라인 항목 (단일 작업/성과) */
+export interface CareerItem {
+  id: string;
+  /** 작업 제목 */
+  title: string;
+  /** 한 줄 성과 요약 */
+  summary: string;
+  /** 작업 유형 */
+  category: CareerCategory;
+  /** 정렬·표기 기준일 (형식: "YYYY.MM") */
+  date: string;
+  /** 표기용 기간 문자열 (예: "2025.06 ~ 2025.09"). 없으면 date 단독 표기 */
+  period?: string;
+  /** 대표 성과 강조 여부 */
+  highlight?: boolean;
+  /** 향후 블로그 글 연결용 slug */
+  postSlug?: string;
+}
+
+/** 회사 경력 (회사 정보 + 작업 항목 목록) */
+export interface Company {
+  /** 회사명 */
+  name: string;
+  /** 담당 역할 */
+  role: string;
+  /** 재직 기간 (예: "2022.06 ~ 재직 중") */
+  period: string;
+  /** 회사/담당 업무 소개 */
+  description: string;
+  /** 수행 작업 항목 */
+  items: CareerItem[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,9 @@ export type { GlossaryEntry } from "./glossary";
 export type { Project } from "./project";
 export type { SearchResult, SearchMatch, SearchOptions } from "./search";
 export type { CategoryNode, SubcategoryNode, CategoryTree } from "./category";
+export type {
+  CareerCategory,
+  CareerCategoryFilter,
+  CareerItem,
+  Company,
+} from "./career";

--- a/src/utils/__tests__/career.test.ts
+++ b/src/utils/__tests__/career.test.ts
@@ -1,0 +1,117 @@
+import {
+  sortByDateDesc,
+  filterByCategory,
+  extractCategoriesWithCount,
+  type CategoryCount,
+} from "../career";
+import type { CareerItem } from "@/types";
+
+function createItem(overrides: Partial<CareerItem> = {}): CareerItem {
+  return {
+    id: "test",
+    title: "Test Item",
+    summary: "Test summary",
+    category: "성능",
+    date: "2025.01",
+    ...overrides,
+  };
+}
+
+describe("sortByDateDesc", () => {
+  it("date 내림차순(최신순)으로 정렬한다", () => {
+    const items = [
+      createItem({ id: "a", date: "2024.03" }),
+      createItem({ id: "b", date: "2026.05" }),
+      createItem({ id: "c", date: "2025.07" }),
+    ];
+
+    const result = sortByDateDesc(items);
+
+    expect(result.map((i) => i.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("같은 date면 입력 순서를 유지한다 (안정 정렬)", () => {
+    const items = [
+      createItem({ id: "a", date: "2026.04" }),
+      createItem({ id: "b", date: "2026.04" }),
+    ];
+
+    const result = sortByDateDesc(items);
+
+    expect(result.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  it("원본 배열을 변경하지 않는다 (불변)", () => {
+    const items = [
+      createItem({ id: "a", date: "2024.03" }),
+      createItem({ id: "b", date: "2026.05" }),
+    ];
+
+    sortByDateDesc(items);
+
+    expect(items.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  it("빈 배열 입력 시 빈 배열을 반환한다", () => {
+    expect(sortByDateDesc([])).toEqual([]);
+  });
+});
+
+describe("filterByCategory", () => {
+  const items = [
+    createItem({ id: "a", category: "성능" }),
+    createItem({ id: "b", category: "보안" }),
+    createItem({ id: "c", category: "성능" }),
+    createItem({ id: "d", category: "인프라" }),
+  ];
+
+  it('"전체" 필터는 모든 항목을 반환한다', () => {
+    expect(filterByCategory(items, "전체")).toHaveLength(4);
+  });
+
+  it("특정 유형 필터는 해당 유형 항목만 반환한다", () => {
+    const result = filterByCategory(items, "성능");
+
+    expect(result.map((i) => i.id)).toEqual(["a", "c"]);
+  });
+
+  it("일치하는 항목이 없으면 빈 배열을 반환한다", () => {
+    expect(filterByCategory(items, "아키텍처")).toEqual([]);
+  });
+});
+
+describe("extractCategoriesWithCount", () => {
+  it("고정 우선순위(성능→보안→아키텍처→인프라)로 유형별 개수를 반환한다", () => {
+    const items = [
+      createItem({ category: "인프라" }),
+      createItem({ category: "성능" }),
+      createItem({ category: "보안" }),
+      createItem({ category: "성능" }),
+      createItem({ category: "아키텍처" }),
+    ];
+
+    const result = extractCategoriesWithCount(items);
+
+    expect(result).toEqual<CategoryCount[]>([
+      { category: "성능", count: 2 },
+      { category: "보안", count: 1 },
+      { category: "아키텍처", count: 1 },
+      { category: "인프라", count: 1 },
+    ]);
+  });
+
+  it("존재하지 않는 유형은 결과에서 제외한다", () => {
+    const items = [
+      createItem({ category: "성능" }),
+      createItem({ category: "보안" }),
+    ];
+
+    const result = extractCategoriesWithCount(items);
+
+    expect(result.map((c) => c.category)).toEqual(["성능", "보안"]);
+  });
+
+  it("빈 배열 입력 시 빈 배열을 반환한다", () => {
+    expect(extractCategoriesWithCount([])).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/career.test.ts
+++ b/src/utils/__tests__/career.test.ts
@@ -2,6 +2,7 @@ import {
   sortByDateDesc,
   filterByCategory,
   extractCategoriesWithCount,
+  groupByYear,
   type CategoryCount,
 } from "../career";
 import type { CareerItem } from "@/types";
@@ -113,5 +114,62 @@ describe("extractCategoriesWithCount", () => {
 
   it("빈 배열 입력 시 빈 배열을 반환한다", () => {
     expect(extractCategoriesWithCount([])).toEqual([]);
+  });
+});
+
+describe("groupByYear", () => {
+  it("date의 연도별로 묶고 연도 내림차순으로 반환한다", () => {
+    const items = [
+      createItem({ id: "a", date: "2024.03" }),
+      createItem({ id: "b", date: "2026.05" }),
+      createItem({ id: "c", date: "2025.07" }),
+    ];
+
+    const result = groupByYear(items);
+
+    expect(result.map((g) => g.year)).toEqual(["2026", "2025", "2024"]);
+  });
+
+  it("같은 연도 내에서는 date 내림차순(최신순)으로 정렬한다", () => {
+    const items = [
+      createItem({ id: "a", date: "2025.03" }),
+      createItem({ id: "b", date: "2025.11" }),
+      createItem({ id: "c", date: "2025.07" }),
+    ];
+
+    const result = groupByYear(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].year).toBe("2025");
+    expect(result[0].items.map((i) => i.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("여러 연도의 항목을 각 연도 그룹으로 분리한다", () => {
+    const items = [
+      createItem({ id: "a", date: "2026.01" }),
+      createItem({ id: "b", date: "2026.09" }),
+      createItem({ id: "c", date: "2024.05" }),
+    ];
+
+    const result = groupByYear(items);
+
+    expect(result.map((g) => g.year)).toEqual(["2026", "2024"]);
+    expect(result[0].items.map((i) => i.id)).toEqual(["b", "a"]);
+    expect(result[1].items.map((i) => i.id)).toEqual(["c"]);
+  });
+
+  it("원본 배열을 변경하지 않는다 (불변)", () => {
+    const items = [
+      createItem({ id: "a", date: "2024.03" }),
+      createItem({ id: "b", date: "2026.05" }),
+    ];
+
+    groupByYear(items);
+
+    expect(items.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  it("빈 배열 입력 시 빈 배열을 반환한다", () => {
+    expect(groupByYear([])).toEqual([]);
   });
 });

--- a/src/utils/career.ts
+++ b/src/utils/career.ts
@@ -23,6 +23,7 @@ const CATEGORY_ORDER: readonly CareerCategory[] = [
   "보안",
   "아키텍처",
   "인프라",
+  "프로젝트",
 ];
 
 /**

--- a/src/utils/career.ts
+++ b/src/utils/career.ts
@@ -10,6 +10,13 @@ export interface CategoryCount {
   count: number;
 }
 
+/** 연도별 묶음 (타임라인 연도 마커용) */
+export interface CareerYearGroup {
+  /** 연도 문자열 (예: "2026") */
+  year: string;
+  items: CareerItem[];
+}
+
 /** 유형 칩의 고정 표시 우선순위 */
 const CATEGORY_ORDER: readonly CareerCategory[] = [
   "성능",
@@ -55,4 +62,27 @@ export function extractCategoriesWithCount(
   return CATEGORY_ORDER.filter((category) => countMap.has(category)).map(
     (category) => ({ category, count: countMap.get(category)! })
   );
+}
+
+/**
+ * 항목을 date의 연도별로 묶는다.
+ * 연도는 내림차순, 각 연도 내 항목은 date 내림차순(최신순)으로 정렬한다.
+ * 원본 배열을 변경하지 않는다.
+ */
+export function groupByYear(items: CareerItem[]): CareerYearGroup[] {
+  const groupMap = new Map<string, CareerItem[]>();
+
+  for (const item of sortByDateDesc(items)) {
+    const year = item.date.slice(0, 4);
+    const group = groupMap.get(year);
+    if (group) {
+      group.push(item);
+    } else {
+      groupMap.set(year, [item]);
+    }
+  }
+
+  return Array.from(groupMap.keys())
+    .sort((a, b) => b.localeCompare(a))
+    .map((year) => ({ year, items: groupMap.get(year)! }));
 }

--- a/src/utils/career.ts
+++ b/src/utils/career.ts
@@ -1,0 +1,58 @@
+import type {
+  CareerCategory,
+  CareerCategoryFilter,
+  CareerItem,
+} from "@/types";
+
+/** 유형 필터 칩 표시용 집계 결과 */
+export interface CategoryCount {
+  category: CareerCategory;
+  count: number;
+}
+
+/** 유형 칩의 고정 표시 우선순위 */
+const CATEGORY_ORDER: readonly CareerCategory[] = [
+  "성능",
+  "보안",
+  "아키텍처",
+  "인프라",
+];
+
+/**
+ * date("YYYY.MM") 내림차순(최신순)으로 정렬한다.
+ * 원본을 변경하지 않으며, 같은 date는 입력 순서를 유지한다(안정 정렬).
+ */
+export function sortByDateDesc(items: CareerItem[]): CareerItem[] {
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => b.item.date.localeCompare(a.item.date) || a.index - b.index)
+    .map(({ item }) => item);
+}
+
+/**
+ * 유형으로 항목을 필터링한다. "전체"는 모든 항목을 반환한다.
+ */
+export function filterByCategory(
+  items: CareerItem[],
+  filter: CareerCategoryFilter
+): CareerItem[] {
+  if (filter === "전체") return items;
+  return items.filter((item) => item.category === filter);
+}
+
+/**
+ * 항목 배열에서 존재하는 유형만 고정 우선순위 순으로 개수와 함께 추출한다.
+ */
+export function extractCategoriesWithCount(
+  items: CareerItem[]
+): CategoryCount[] {
+  const countMap = new Map<CareerCategory, number>();
+
+  for (const item of items) {
+    countMap.set(item.category, (countMap.get(item.category) ?? 0) + 1);
+  }
+
+  return CATEGORY_ORDER.filter((category) => countMap.has(category)).map(
+    (category) => ({ category, count: countMap.get(category)! })
+  );
+}


### PR DESCRIPTION
## 개요
About/Projects와 분리된 전용 **Career 페이지(`/career`)** 를 신설하고, 소속별 경력을 연도 타임라인으로 정리한다.

---

## 주요 변경

### 1. Career 페이지 신설 (`e6bb676`)
- `/career` 라우트 + 네비게이션 `Career` 추가, About 하단 "경력 보기" 링크
- 데이터/뷰 분리: `types/career`, `data/career`, `utils/career`(정렬·필터·집계)
- 유형 필터 칩(성능·보안·아키텍처·인프라), 다크모드, TiltCard 적용

### 2. 아코디언 토글 + 연도 그룹핑 (`3cddf05`)
- 회사 카드를 헤더-행 클릭 아코디언으로 전환 (`h2 > button`, `aria-expanded`/`aria-controls`, 키보드 지원, `inert`)
- `grid-rows 0fr↔1fr` 높이 애니메이션 + `prefers-reduced-motion` 대응
- 타임라인을 연도별로 묶어 연혁처럼 표시, "대표 성과(⭐)" 범례 추가

### 3. 다중 소속 + 공주대 연구실 (`92f38a2`)
- `company` 단일 → `careers: Company[]` 다중 소속 구조 전환
- 공주대학교 네트워크보안연구실(학부 연구생, 2019.06~2022.02) + IoT·블록체인 프로젝트 3건(GitHub 링크 포함)
- `CareerItem.repoUrl`, `CareerCategory`에 "프로젝트" 추가
- 유형 1개뿐이면 필터 칩 자동 숨김, `repoUrl` 시 GitHub 링크 렌더

---

## 수정 파일
- 신규: `app/career/page.tsx`, `components/CareerSection.tsx`, `components/CareerTimeline.tsx`, `types/career.ts`, `data/career.ts`, `utils/career.ts`
- 수정: `app/layout.tsx`(네비), `app/about/page.tsx`(링크), `types/index.ts`

## 테스트
- 유틸 15케이스(`sortByDateDesc`/`filterByCategory`/`extractCategoriesWithCount`/`groupByYear`)
- 컴포넌트 11케이스(아코디언 토글·필터 칩 노출·GitHub 링크)
- 전체 507개 통과, `next build` SSG 통과

## 비고
- 셀프 코드리뷰 결과 CRITICAL/HIGH 없음. LOW 3건(연도 마커 리스트 시맨틱 등)은 후속 개선 여지