### PR TITLE
fix(blog): 목차 앵커 slug를 rehype-slug와 동일 규칙으로 통일

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ import fs from "fs";
 
 const nextConfig: NextConfig = {
   output: "export",
+  // github-slugger는 ESM 전용 패키지. next/jest가 이를 SWC로 변환하도록 허용해
+  // 목차 slug를 rehype-slug와 동일한 규칙으로 생성한다.
+  transpilePackages: ["github-slugger"],
   images: {
     unoptimized: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@giscus/react": "^3.1.0",
         "@tailwindcss/typography": "^0.5.19",
+        "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "next": "^16.2.2",
         "next-mdx-remote": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@giscus/react": "^3.1.0",
     "@tailwindcss/typography": "^0.5.19",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "^16.2.2",
     "next-mdx-remote": "^6.0.0",

--- a/src/lib/__tests__/toc.test.ts
+++ b/src/lib/__tests__/toc.test.ts
@@ -1,0 +1,67 @@
+import GithubSlugger from "github-slugger";
+import { extractHeadings } from "@/lib/toc";
+
+/**
+ * extractHeadings 슬러그 생성 테스트.
+ *
+ * 핵심 이슈: 목차 링크 slug와 실제 heading id(rehype-slug = github-slugger)가
+ * 서로 다른 규칙으로 생성되어, 엠대시(—) 등이 든 제목에서
+ * getElementById가 null을 반환 → 목차 클릭 시 스크롤 안 됨.
+ *
+ * 수정 방향: extractHeadings도 rehype-slug와 동일한 github-slugger로 slug를 생성해
+ * 두 지점의 slug 규칙을 단일 출처로 통일한다.
+ */
+describe("extractHeadings", () => {
+  test("### / ## 헤딩을 level·text와 함께 추출한다", () => {
+    const content = ["## 소개", "### 설치 방법", "본문", "## 사용법"].join("\n");
+
+    const result = extractHeadings(content);
+
+    expect(result).toEqual([
+      { slug: "소개", text: "소개", level: 2 },
+      { slug: "설치-방법", text: "설치 방법", level: 3 },
+      { slug: "사용법", text: "사용법", level: 2 },
+    ]);
+  });
+
+  test("헤딩이 아닌 라인(#, ####)은 무시한다", () => {
+    const content = ["# 최상위 제목", "#### 너무 깊은 제목", "일반 문단"].join(
+      "\n"
+    );
+
+    expect(extractHeadings(content)).toEqual([]);
+  });
+
+  describe("rehype-slug(github-slugger)와 slug 규칙이 일치한다", () => {
+    // 실제 렌더된 heading id의 출처인 github-slugger와 동일해야
+    // 목차 클릭 시 getElementById가 요소를 찾는다.
+    const cases = [
+      // 버그 재현: 엠대시(—) 양옆 공백 → github-slugger는 이중 하이픈(--) 생성
+      "왜 필요했나 — 같은 DB를 보는 두 서버",
+      "기대 — UPDATE가 자동으로 막아줄 것이다",
+      "동시성 경합의 정체 — Lost Update와 TOCTOU",
+      // 기존 정상 케이스(회귀 방지)
+      "Lost Update (갱신 손실)",
+      "TOCTOU (Time-Of-Check-To-Time-Of-Use)",
+    ];
+
+    test.each(cases)("«%s»", (heading) => {
+      const expected = new GithubSlugger().slug(heading);
+      const [item] = extractHeadings(`## ${heading}`);
+      expect(item.slug).toBe(expected);
+    });
+  });
+
+  test("엠대시가 든 제목은 이중 하이픈 slug를 생성한다(버그 재현)", () => {
+    const [item] = extractHeadings("## 왜 필요했나 — 같은 DB를 보는 두 서버");
+    expect(item.slug).toBe("왜-필요했나--같은-db를-보는-두-서버");
+  });
+
+  test("동일 제목이 반복되면 github-slugger처럼 -1, -2 접미사를 붙인다", () => {
+    const content = ["## 정리", "## 정리", "## 정리"].join("\n");
+
+    const slugs = extractHeadings(content).map((h) => h.slug);
+
+    expect(slugs).toEqual(["정리", "정리-1", "정리-2"]);
+  });
+});

--- a/src/lib/toc.ts
+++ b/src/lib/toc.ts
@@ -1,3 +1,5 @@
+import GithubSlugger from "github-slugger";
+
 export interface TocItem {
   slug: string;
   text: string;
@@ -5,22 +7,22 @@ export interface TocItem {
 }
 
 /**
- * 마크다운 콘텐츠에서 헤딩을 추출하여 목차 아이템 배열로 반환
+ * 마크다운 콘텐츠에서 헤딩을 추출하여 목차 아이템 배열로 반환.
+ *
+ * slug는 실제 heading id를 생성하는 rehype-slug와 동일한 github-slugger로 만든다.
+ * (수제 정규식으로 별도 생성하면 엠대시 등에서 규칙이 어긋나 목차 클릭이 깨졌다.)
+ * slugger 인스턴스를 콘텐츠당 1개만 사용해야 중복 제목의 -1/-2 접미사까지 일치한다.
  */
 export function extractHeadings(content: string): TocItem[] {
   const headingRegex = /^(#{2,3})\s+(.+)$/gm;
   const headings: TocItem[] = [];
+  const slugger = new GithubSlugger();
 
   let match;
   while ((match = headingRegex.exec(content)) !== null) {
     const level = match[1].length;
     const text = match[2].trim();
-    const slug = text
-      .toLowerCase()
-      .replace(/[^a-z0-9가-힣\s-]/g, "")
-      .replace(/\s+/g, "-");
-
-    headings.push({ slug, text, level });
+    headings.push({ slug: slugger.slug(text), text, level });
   }
 
   return headings;


### PR DESCRIPTION
## 개요
목차(ToC) 항목을 클릭해도 해당 제목으로 스크롤되지 않던 버그를 수정합니다. 특정 글에서 `Lost Update(갱신 손실)` 목차 항목부터만 이동이 동작하던 문제입니다.

## 근본 원인
목차 링크의 앵커 slug와 실제 heading `id`가 **서로 다른 규칙**으로 생성되어, 특정 문자에서 어긋났습니다.

| 위치 | 생성 방식 | 공백 처리 |
|------|-----------|-----------|
| 실제 heading id (`page.tsx`, `rehype-slug`) | github-slugger | 공백을 개별 `-`로 치환 → `--` |
| 목차 링크 (`toc.ts`, 수제 정규식) | `.replace(/\s+/g, "-")` | 연속 공백을 하나로 합침 → `-` |

엠대시(`—`)는 양옆에 공백이 있어 제거 후 공백이 2개 남습니다. 이걸 두 슬러거가 다르게 처리해:
- 실제 id: `왜-필요했나--같은-db…` (이중 하이픈)
- 목차 href: `왜-필요했나-같은-db…` (단일 하이픈)

→ `getElementById(slug)`가 `null`을 반환해 클릭 시 스크롤이 일어나지 않았습니다. 엠대시가 없는 첫 제목(`Lost Update (갱신 손실)`)부터 동작한 이유입니다.

## 변경 사항
- `src/lib/toc.ts`: `extractHeadings`가 heading id 생성과 **동일한 github-slugger**를 사용하도록 변경 (수제 정규식 제거, slug 규칙 단일 출처화). 콘텐츠당 slugger 인스턴스 1개 → 중복 제목의 `-1`/`-2` 접미사까지 일치.
- `next.config.ts`: github-slugger가 ESM 전용이라 `transpilePackages`에 추가해 next/jest(SWC)가 변환하도록 함.
- `package.json`: github-slugger를 직접 의존성으로 명시 (기존 rehype-slug의 전이 의존성).
- `src/lib/__tests__/toc.test.ts` (신규): 버그 재현 + rehype-slug 파리티 + 중복 접미사 검증.

## 테스트
- 신규 단위 테스트 9/9 통과
- 전체 jest 516 통과 (기존 무관한 2개 스위트 제외)
- `next build`(프로덕션 SSG) 성공
- 엔드투엔드: 실제 글을 빌드해 렌더된 heading id ↔ 목차 href 대조 → 31/31 일치 (엠대시 헤딩 포함 정상화)