### PR TITLE
feat: sitemap.xml + robots.txt 추가 (#122)

### DIFF
--- a/src/app/__tests__/metadata-routes.test.ts
+++ b/src/app/__tests__/metadata-routes.test.ts
@@ -1,0 +1,50 @@
+import sitemap from "../sitemap";
+import robots from "../robots";
+import { SITE_URL } from "@/lib/constants";
+import { STATIC_ROUTES } from "@/lib/sitemap";
+import { postService } from "@/lib/container";
+
+describe("robots", () => {
+  it("모든 크롤러를 허용한다", () => {
+    const result = robots();
+    expect(result.rules).toEqual({ userAgent: "*", allow: "/" });
+  });
+
+  it("sitemap.xml 위치를 명시한다", () => {
+    const result = robots();
+    expect(result.sitemap).toBe(`${SITE_URL}/sitemap.xml`);
+  });
+
+  it("host를 사이트 URL로 설정한다", () => {
+    const result = robots();
+    expect(result.host).toBe(SITE_URL);
+  });
+});
+
+describe("sitemap 라우트", () => {
+  it("정적 라우트와 실제 전체 포스트를 모두 포함한다", () => {
+    const result = sitemap();
+    const postCount = postService.getAllPosts().length;
+
+    expect(result).toHaveLength(STATIC_ROUTES.length + postCount);
+  });
+
+  it("모든 URL이 사이트 URL로 시작하고 후행 슬래시로 끝난다", () => {
+    const result = sitemap();
+
+    for (const entry of result) {
+      expect(entry.url.startsWith(SITE_URL)).toBe(true);
+      expect(entry.url.endsWith("/")).toBe(true);
+    }
+  });
+
+  it("실제 포스트 slug가 /blog/{slug}/ 형태로 포함된다", () => {
+    const result = sitemap();
+    const posts = postService.getAllPosts();
+    const urls = new Set(result.map((e) => e.url));
+
+    for (const post of posts) {
+      expect(urls.has(`${SITE_URL}/blog/${post.slug}/`)).toBe(true);
+    }
+  });
+});

--- a/src/app/__tests__/metadata-routes.test.ts
+++ b/src/app/__tests__/metadata-routes.test.ts
@@ -12,12 +12,16 @@ describe("robots", () => {
 
   it("sitemap.xml 위치를 명시한다", () => {
     const result = robots();
-    expect(result.sitemap).toBe(`${SITE_URL}/sitemap.xml`);
+
+    // SITE_URL을 그대로 보간하지 않고 리터럴로 검증해 실제 회귀를 잡는다.
+    expect(result.sitemap).toBe("https://kmg733.github.io/sitemap.xml");
+    // 스킴 뒤(//)를 제외한 중복 슬래시가 없어야 한다 (SITE_URL 후행 슬래시 회귀 방지).
+    expect(result.sitemap).not.toMatch(/[^:]\/\//);
   });
 
   it("host를 사이트 URL로 설정한다", () => {
     const result = robots();
-    expect(result.host).toBe(SITE_URL);
+    expect(result.host).toBe("https://kmg733.github.io");
   });
 });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import MouseRipple from "@/components/MouseRipple";
 
 import NavLink from "@/components/NavLink";
 import { postService } from "@/lib/container";
+import { SITE_URL } from "@/lib/constants";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -29,6 +30,7 @@ const sacramento = Sacramento({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "Manuel",
     template: "%s | Manuel",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/constants";
+
+// output: export 모드에서 정적 파일(robots.txt)로 생성되도록 강제한다.
+export const dynamic = "force-static";
+
+/**
+ * robots.txt 생성 (Next.js 16 MetadataRoute API).
+ * 모든 크롤러 허용 + sitemap 위치 명시.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { postService } from "@/lib/container";
+import { buildSitemap } from "@/lib/sitemap";
+import { SITE_URL } from "@/lib/constants";
+
+// output: export 모드에서 정적 파일(sitemap.xml)로 생성되도록 강제한다.
+export const dynamic = "force-static";
+
+/**
+ * sitemap.xml 생성 (Next.js 16 MetadataRoute API).
+ * 정적 export 시 빌드 타임에 sitemap.xml로 렌더링된다.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  return buildSitemap(postService.getAllPosts(), SITE_URL);
+}

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -1,0 +1,12 @@
+import { SITE_URL } from "../constants";
+
+describe("SITE_URL", () => {
+  it("후행 슬래시 없이 정규화되어 export된다", () => {
+    // sitemap/robots의 URL 조합이 이 불변식에 의존한다.
+    expect(SITE_URL.endsWith("/")).toBe(false);
+  });
+
+  it("절대 URL 형태다", () => {
+    expect(SITE_URL).toMatch(/^https?:\/\/[^/]+$/);
+  });
+});

--- a/src/lib/__tests__/sitemap.test.ts
+++ b/src/lib/__tests__/sitemap.test.ts
@@ -1,0 +1,104 @@
+import { buildSitemap, STATIC_ROUTES } from "../sitemap";
+import type { PostMeta } from "@/types";
+
+const SITE_URL = "https://example.com";
+
+function createPost(overrides: Partial<PostMeta> = {}): PostMeta {
+  return {
+    slug: "test-post",
+    title: "Test Post",
+    date: "2025-01-01",
+    description: "Test description",
+    category: "dev",
+    tags: ["javascript"],
+    readingTime: "5 min read",
+    ...overrides,
+  };
+}
+
+describe("buildSitemap", () => {
+  it("모든 정적 라우트를 포함한다", () => {
+    const result = buildSitemap([], SITE_URL);
+    const urls = result.map((e) => e.url);
+
+    expect(urls).toContain(`${SITE_URL}/`);
+    expect(urls).toContain(`${SITE_URL}/blog/`);
+    expect(urls).toContain(`${SITE_URL}/about/`);
+    expect(urls).toContain(`${SITE_URL}/career/`);
+    expect(urls).toContain(`${SITE_URL}/projects/`);
+    expect(result).toHaveLength(STATIC_ROUTES.length);
+  });
+
+  it("모든 포스트 URL을 후행 슬래시와 함께 포함한다", () => {
+    const posts = [
+      createPost({ slug: "post-a" }),
+      createPost({ slug: "post-b" }),
+    ];
+
+    const result = buildSitemap(posts, SITE_URL);
+    const urls = result.map((e) => e.url);
+
+    expect(urls).toContain(`${SITE_URL}/blog/post-a/`);
+    expect(urls).toContain(`${SITE_URL}/blog/post-b/`);
+    expect(result).toHaveLength(STATIC_ROUTES.length + posts.length);
+  });
+
+  it("포스트의 lastModified는 frontmatter date를 사용한다", () => {
+    const posts = [createPost({ slug: "dated", date: "2024-03-15" })];
+
+    const result = buildSitemap(posts, SITE_URL);
+    const entry = result.find((e) => e.url === `${SITE_URL}/blog/dated/`);
+
+    expect(entry?.lastModified).toEqual(new Date("2024-03-15"));
+  });
+
+  it("홈/블로그의 lastModified는 최신 포스트 발행일을 사용한다", () => {
+    const posts = [
+      createPost({ slug: "old", date: "2024-01-01" }),
+      createPost({ slug: "newest", date: "2025-06-30" }),
+      createPost({ slug: "mid", date: "2024-12-01" }),
+    ];
+
+    const result = buildSitemap(posts, SITE_URL);
+    const home = result.find((e) => e.url === `${SITE_URL}/`);
+    const blog = result.find((e) => e.url === `${SITE_URL}/blog/`);
+
+    expect(home?.lastModified).toEqual(new Date("2025-06-30"));
+    expect(blog?.lastModified).toEqual(new Date("2025-06-30"));
+  });
+
+  it("정적 콘텐츠 페이지(about/career/projects)는 lastModified를 생략한다", () => {
+    const result = buildSitemap([createPost()], SITE_URL);
+
+    for (const path of ["about", "career", "projects"]) {
+      const entry = result.find((e) => e.url === `${SITE_URL}/${path}/`);
+      expect(entry?.lastModified).toBeUndefined();
+    }
+  });
+
+  it("포스트가 없으면 홈/블로그도 lastModified를 생략한다", () => {
+    const result = buildSitemap([], SITE_URL);
+    const home = result.find((e) => e.url === `${SITE_URL}/`);
+
+    expect(home?.lastModified).toBeUndefined();
+  });
+
+  it("홈은 priority 1, 포스트는 priority 0.7을 가진다", () => {
+    const result = buildSitemap([createPost({ slug: "p" })], SITE_URL);
+
+    const home = result.find((e) => e.url === `${SITE_URL}/`);
+    const post = result.find((e) => e.url === `${SITE_URL}/blog/p/`);
+
+    expect(home?.priority).toBe(1);
+    expect(post?.priority).toBe(0.7);
+  });
+
+  it("siteUrl 끝에 슬래시가 있어도 URL이 중복 슬래시 없이 생성된다", () => {
+    const result = buildSitemap([createPost({ slug: "p" })], "https://example.com/");
+    const urls = result.map((e) => e.url);
+
+    expect(urls).toContain("https://example.com/");
+    expect(urls).toContain("https://example.com/blog/p/");
+    expect(urls.every((u) => !u.includes("//blog"))).toBe(true);
+  });
+});

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,9 @@
  * 애플리케이션 전역 상수
  */
 
+// 사이트 기본 정보 (후행 슬래시 없이 관리한다 — sitemap/robots URL 조합 규약)
+export const SITE_URL = "https://kmg733.github.io";
+
 // 포스트 관련 상수
 export const POST_DEFAULTS = {
   DIRECTORY: "content/posts",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,8 +2,10 @@
  * 애플리케이션 전역 상수
  */
 
-// 사이트 기본 정보 (후행 슬래시 없이 관리한다 — sitemap/robots URL 조합 규약)
-export const SITE_URL = "https://kmg733.github.io";
+// 사이트 기본 정보
+// export 시점에 후행 슬래시를 제거해, 값이 어떻게 바뀌든(예: 환경변수 전환)
+// sitemap/robots의 URL 조합이 의존하는 "후행 슬래시 없음" 불변식을 단일 소스에서 강제한다.
+export const SITE_URL = "https://kmg733.github.io".replace(/\/+$/, "");
 
 // 포스트 관련 상수
 export const POST_DEFAULTS = {

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,85 @@
+import type { MetadataRoute } from "next";
+import type { PostMeta } from "@/types";
+
+type ChangeFrequency = NonNullable<
+  MetadataRoute.Sitemap[number]["changeFrequency"]
+>;
+
+interface StaticRoute {
+  readonly path: string;
+  readonly changeFrequency: ChangeFrequency;
+  readonly priority: number;
+  /**
+   * 포스트 목록에 의존하는 페이지(홈/블로그)는 최신 포스트 발행일을
+   * lastModified로 사용한다. 그 외 정적 콘텐츠 페이지는 실제 변경일을
+   * 추적할 수 없으므로 lastModified를 생략한다(부정확한 신호 방지).
+   */
+  readonly lastmodFromLatestPost?: boolean;
+}
+
+/**
+ * 정적 라우트 목록 (SSG로 생성되는 독립 HTML 페이지).
+ * 카테고리(/blog?category=...)는 쿼리파라미터 기반 클라이언트 필터로
+ * 독립 페이지가 아니므로 sitemap에 포함하지 않는다.
+ */
+export const STATIC_ROUTES: readonly StaticRoute[] = [
+  { path: "/", changeFrequency: "daily", priority: 1, lastmodFromLatestPost: true },
+  { path: "/blog", changeFrequency: "daily", priority: 0.9, lastmodFromLatestPost: true },
+  { path: "/about", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/career", changeFrequency: "monthly", priority: 0.5 },
+  { path: "/projects", changeFrequency: "monthly", priority: 0.5 },
+];
+
+/**
+ * siteUrl과 경로를 결합해 후행 슬래시가 붙은 정규 페이지 URL을 만든다.
+ * next.config의 `trailingSlash: true` 설정과 일치시킨다.
+ * 주의: 파일 URL(.xml 등)이 아닌 페이지 경로 전용이다.
+ */
+export function toUrl(siteUrl: string, path: string): string {
+  const base = siteUrl.replace(/\/+$/, "");
+  const trimmed = path.replace(/^\/+|\/+$/g, "");
+  return trimmed ? `${base}/${trimmed}/` : `${base}/`;
+}
+
+/**
+ * 포스트 중 가장 최근 발행일을 반환한다. 포스트가 없으면 undefined.
+ */
+function latestPostDate(
+  posts: Pick<PostMeta, "date">[]
+): Date | undefined {
+  if (posts.length === 0) return undefined;
+  const latest = Math.max(...posts.map((p) => new Date(p.date).getTime()));
+  return new Date(latest);
+}
+
+/**
+ * 정적 라우트와 전체 포스트를 합쳐 sitemap 엔트리를 생성한다.
+ * @param posts 포스트 메타 (slug, date만 사용)
+ * @param siteUrl 사이트 기본 URL
+ */
+export function buildSitemap(
+  posts: Pick<PostMeta, "slug" | "date">[],
+  siteUrl: string
+): MetadataRoute.Sitemap {
+  const latest = latestPostDate(posts);
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_ROUTES.map((route) => {
+    const entry = {
+      url: toUrl(siteUrl, route.path),
+      changeFrequency: route.changeFrequency,
+      priority: route.priority,
+    };
+    return route.lastmodFromLatestPost && latest
+      ? { ...entry, lastModified: latest }
+      : entry;
+  });
+
+  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: toUrl(siteUrl, `/blog/${post.slug}`),
+    lastModified: new Date(post.date),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [...staticEntries, ...postEntries];
+}


### PR DESCRIPTION
## 개요
검색 엔진 색인을 위한 `sitemap.xml`과 `robots.txt`를 Next.js 16 `MetadataRoute` API로 추가한다.

Closes #122

## 작업 내용
- **`src/lib/sitemap.ts`** (신규): 정적 라우트 + 전체 포스트 URL을 생성하는 순수 빌더 `buildSitemap`. `trailingSlash: true` 설정에 맞춰 후행 슬래시로 정규화
- **`src/app/sitemap.ts`**, **`src/app/robots.ts`** (신규): 라우트 래퍼. `output: export` 모드에서 정적 파일로 생성되도록 `dynamic = "force-static"` 지정
- **`src/lib/constants.ts`**: `SITE_URL` 상수 추가
- **`src/app/layout.tsx`**: `metadataBase` 추가로 절대 URL 메타태그 일관성 확보

## 설계 결정
- **lastModified**
  - 홈/블로그: 최신 포스트 발행일 사용 (실제 콘텐츠 변경 신호)
  - about/career/projects: 실제 변경 이력을 추적할 수 없어 생략 (부정확한 신호 방지)
  - 포스트: frontmatter `date` 사용
- **카테고리 제외**: 카테고리는 `/blog?category=...` 쿼리파라미터 기반 클라이언트 필터로 독립 HTML 페이지가 없음. 쿼리 URL을 sitemap에 넣으면 중복 콘텐츠로 판단되므로 표준에 따라 제외

## 후속 과제
- 포스트 수정일 반영을 위한 frontmatter `updatedAt` 필드 도입 (별도 이슈)

## 테스트
- `src/lib/__tests__/sitemap.test.ts`: 빌더 단위 테스트 8개
- `src/app/__tests__/metadata-routes.test.ts`: 라우트/robots 통합 테스트 6개
- 전체 528+ 테스트 통과, 프로덕션 빌드(SSG export) 성공
- 산출물 검증: `out/sitemap.xml`(22 URL = 정적 5 + 포스트 17), `out/robots.txt` 정상 생성