### PR TITLE
docs: CLAUDE.md 현재 프로젝트 구조에 맞게 최신화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,37 +4,59 @@ Next.js 기반 개인 블로그 프로젝트 (`kmg733.github.io`)
 
 ## 기술 스택
 
-- **Framework**: Next.js 16 (App Router, SSG)
+- **Framework**: Next.js 16 (App Router) — 정적 내보내기(`output: "export"`)로 GitHub Pages 배포
+- **UI**: React 19, Tailwind CSS (+ `@tailwindcss/typography`) + `globals.css`
 - **Language**: TypeScript
 - **MDX**: next-mdx-remote v6 (RSC)
-- **Code Highlighting**: rehype-pretty-code + Shiki
-- **Styling**: Tailwind CSS + globals.css
+- **코드 하이라이팅**: rehype-pretty-code + Shiki
+- **마크다운 확장**: remark-gfm, rehype-slug, github-slugger (TOC/앵커 slug)
+- **기타**: sharp(썸네일 최적화), feed(RSS/Atom), @giscus/react(댓글), reading-time
+- **테스트**: Jest + Testing Library
 
 ## 블로그 포스트 작성 규칙
 
 ### 파일 구조
 
 ```
-content/posts/{slug}.md          ← 포스트 본문 (MDX)
-public/images/posts/{slug}/      ← 포스트 이미지 디렉토리
-public/images/thumbnails/        ← 카테고리 썸네일
+content/posts/{slug}.md          # 포스트 본문 (MDX)
+public/images/posts/{slug}/      # 포스트 이미지 (light/dark 쌍)
+public/images/thumbnails/        # 카테고리 썸네일 (sharp로 webp 최적화)
+src/app/                         # App Router 페이지 + RSS(feed.xml)/Atom(atom.xml)
+src/components/                  # UI 컴포넌트 (glossary/Term, CodeBlock, TableOfContents …)
+src/{lib,repositories,services,types}/   # 데이터 로딩 · 도메인 계층
 ```
 
-### Frontmatter 필수 필드
+### Frontmatter 스키마
 
 ```yaml
 ---
+# 필수
 title: "포스트 제목"
 date: "YYYY-MM-DD"
-category: "카테고리명"
-description: "SEO 설명"
-thumbnail: "/images/thumbnails/{category}-{theme}.{ext}"
+category: "카테고리명"                 # 예: "개발"
+description: "SEO/목록용 설명"
+tags: ["guide", "intermediate"]        # 문자열 배열
+
+# 선택
+subcategory: "Java"                    # 카테고리 하위 분류
+thumbnail: "/images/thumbnails/java"   # 접미사·확장자 없는 base 경로
+series: "java-memory"                  # 시리즈 slug
+seriesOrder: 1                         # 시리즈 내 순서
+relatedSlugs: ["other-slug"]           # 관련 글 수동 지정
+comments: true                         # giscus 댓글 노출 여부
+
+# 용어 툴팁 (선택)
 glossary:
-  - id: "term-id"
-    term: "용어"
-    description: "설명"
+  - id: "term-id"                      # 앵커/툴팁 식별자
+    term: "용어 표시명"
+    brief: "툴팁에 뜨는 한 줄 설명"
+    detail: "하단 용어 섹션의 상세 설명"
 ---
 ```
+
+> - `readingTime`은 본문에서 자동 계산되므로 frontmatter에 넣지 않는다.
+> - `thumbnail`은 확장자·테마 접미사 없이 base 경로만 적는다 (`PostThumbnail`이 `-light/-dark`, `webp/png`를 해석).
+> - glossary 항목은 `description`이 아니라 **`brief`(툴팁) + `detail`(상세)** 두 필드를 쓴다.
 
 ### 다이어그램/이미지 규칙
 
@@ -95,12 +117,19 @@ glossary:
 - `.dark` 클래스가 루트 HTML에 있으면 다크 모드 활성화
 - 구현 위치: `src/app/globals.css` (`.prose figure` 스타일 영역)
 
-### MDX 컴포넌트
+### MDX에서 쓸 수 있는 것
 
-| 컴포넌트 | 용도 | 사용법 |
-|---------|------|--------|
-| `Term` | 용어 툴팁 표시 | `<Term id="term-id">표시 텍스트</Term>` |
-| `CodeBlock` | 코드 하이라이팅 (자동) | ` ```lang ` 코드블록 |
+MDX에 등록된 컴포넌트는 `Term`과 코드블록용 `CodeBlock`(`pre` 매핑)뿐이다(`src/app/blog/[slug]/page.tsx`의 `components={{ Term, pre: CodeBlock }}`). 나머지 시각 요소는 `globals.css`가 스타일링하는 HTML + `className` 패턴으로 작성한다.
+
+| 요소 | 형태 | 용도 |
+|------|------|------|
+| `Term` | `<Term id="term-id">표시 텍스트</Term>` | 용어 툴팁 (frontmatter glossary와 연동) |
+| 코드블록 | ` ```lang ` | `CodeBlock`으로 자동 하이라이팅 |
+| 이미지/다이어그램 | `<figure><div className="figure-content"><div className="image-frame">…</div></div></figure>` | 위 "이미지 삽입 패턴" 참고 |
+| 정보 강조 | `<div className="info-box">…</div>` | 부연·팁 박스 |
+| 주의 강조 | `<div className="warning-box">…</div>` | 경고·함정 박스 |
+
+> `figure`·`info-box`·`warning-box`는 컴포넌트가 아니라 `globals.css` 클래스 스타일이다. MDX 안에서 `className`으로 쓴다.
 
 ### 금지 사항
 
@@ -109,12 +138,20 @@ glossary:
 - ❌ `<img>` 태그에 한쪽 테마만 제공
 - ❌ 이미지 없이 텍스트만으로 다이어그램 표현
 
-## 빌드 및 배포
+## 빌드 · 테스트 · 배포
 
 ```bash
-npm run dev          # 개발 서버
-npx next build       # 프로덕션 빌드 (SSG)
+npm run dev            # 개발 서버 (webpack)
+npm run build          # 프로덕션 정적 빌드 (output: "export" → out/)
+npm test               # Jest 테스트
+npm run test:coverage  # 커버리지
+npm run lint           # ESLint
 ```
+
+- **정적 내보내기**: `next.config.ts`의 `output: "export"` → `out/` 생성. `transpilePackages: ["github-slugger", "feed"]`.
+- **prebuild 훅**: `npm run build` 시 `optimize-thumbnails`(sharp)가 먼저 실행돼 썸네일 webp를 만든다.
+- **배포**: `.github/workflows/deploy.yml`로 GitHub Pages 자동 배포.
+- **품질 게이트**: 변경 후 `npx next build` + `npm test`로 정적 생성·테스트 통과를 확인한다.
 
 ## 브랜치 전략
 


### PR DESCRIPTION
## 개요

`CLAUDE.md`가 실제 프로젝트 구조와 어긋나 있어 최신화합니다.

## 변경 내용

- **Frontmatter 스키마 정정**: `tags`(필수), `subcategory`/`series`/`seriesOrder`/`relatedSlugs`/`comments` 추가, glossary는 `description`이 아니라 `brief`+`detail`, `thumbnail`은 접미사·확장자 없는 base 경로, `readingTime` 자동 계산 명시
- **기술 스택 갱신**: React 19, 정적 내보내기(`output: "export"`), github-slugger, sharp, feed(RSS/Atom), giscus, Jest
- **MDX 사용 요소 정리**: 등록 컴포넌트는 `Term`+`CodeBlock`(pre)뿐이며 `info-box`/`warning-box`/`figure`는 `globals.css` 클래스임을 구분
- **빌드·테스트·배포 정정**: 정적 export, prebuild 썸네일 최적화(sharp), GitHub Pages Actions 배포, 테스트 명령
- **파일 구조**: `src/` 계층(app/components/lib 등) 추가

## 비고

- 코드 변경 없음(문서만). 민감정보 없음.